### PR TITLE
Fix: Fix firebase hosting workflow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -18,4 +18,5 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TOY_PROJECT2_TEAM4_FASTCOM4 }}
+          channelId: live
           projectId: toy-project2-team4-fastcom4

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -19,4 +19,5 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TOY_PROJECT2_TEAM4_FASTCOM4 }}
+          channelId: live
           projectId: toy-project2-team4-fastcom4


### PR DESCRIPTION
- Fix firebase hosting workflow
github issue  #8

- github action 스크립트에서 채널 아이디 channelId를 빼먹음.
- 참고 자료-https://firebase.google.com/docs/hosting/manage-hosting-resources?hl=ko