### PR TITLE
design: 하단 navbar 버튼 사이에 padding을 삭제함.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
+        "@mui/base": "^5.0.0-beta.40",
         "@mui/icons-material": "^5.16.5",
         "@mui/joy": "^5.0.0-beta.48",
         "@mui/material": "^5.16.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
+    "@mui/base": "^5.0.0-beta.40",
     "@mui/icons-material": "^5.16.5",
     "@mui/joy": "^5.0.0-beta.48",
     "@mui/material": "^5.16.4",

--- a/src/components/nav/NavBar.style.tsx
+++ b/src/components/nav/NavBar.style.tsx
@@ -16,4 +16,8 @@ export const MyToolbar = styled(Toolbar)`
   flex-grow: 1, calc(100% / 5);
   padding-right: 0;
   padding-left: 0;
+  @media (min-width: 600px) {
+    padding-right: 0px;
+    padding-left: 0px;
+  }
 `;

--- a/src/components/nav/NavButton.style.tsx
+++ b/src/components/nav/NavButton.style.tsx
@@ -21,7 +21,8 @@ export const MUIButton = styled(Button)`
 `;
 
 export const TextBox = styled(Box)`
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: bold;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
@@ -37,6 +38,6 @@ export const IconWrapper = styled(Box)`
   align-items: center;
   margin-bottom: 4px;
   & svg {
-    font-size: 2rem;
+    font-size: 4rem;
   }
 `;


### PR DESCRIPTION
- navbar 스타일에 media query 추가 Github issue #27
- 하단 메뉴칸의 focus 되었을 때 진하게 주황색이 되게함.
- 메뉴 들 사이에 padding을 삭제함
- 아이콘 크기를 4rem 으로 만듬. 40px
![image](https://github.com/user-attachments/assets/3b303cb4-ef76-4d2a-9b14-4505264b3fb6)

