### PR TITLE
[feature] 버튼, 아이콘 버튼 컴포넌트 기본 props 추가

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,36 +1,33 @@
 import StyledButton from './Button.styled';
-import { MouseEventHandler } from 'react';
+import { ButtonProps as MuiButtonProps } from '@mui/joy/Button';
 //btnType의 경우 outlined로 타입을 넣어주지 않을 경우 기본 버튼은 primary
 //size의 경우 sm:기본 버튼, md: 로그인 버튼
 //<Btn label='활성화'/> 예) 기본 버튼
 //<Btn round='true' label='신청하기'/> 예) 동그란 모양의 버튼
 //<Btn disabled label='비활성화'/> 예) 비활성화 버튼
 
-type ButtonProps = {
+type ButtonProps = MuiButtonProps &{
   label: string;
   btntype?: string;
   btnsize?: string;
   round?: string;
   disabled?: boolean;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
 export default function Btn({
   btntype,
-  btnsize,
   label,
   round,
   disabled = false,
-  onClick,
+  ...props
 }: ButtonProps) {
   return (
     <StyledButton
       variant="outlined"
       btntype={btntype}
-      btnsize={btnsize}
       round={round}
       disabled={disabled}
-      onClick={onClick}
+      {...props}
     >
       {label}
     </StyledButton>

--- a/src/components/iconButton/IconButton.tsx
+++ b/src/components/iconButton/IconButton.tsx
@@ -1,44 +1,46 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import CloseIcon from '@mui/icons-material/Close';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
+import DownloadIcon from '@mui/icons-material/Download';
 import EditIcon from '@mui/icons-material/Edit';
 import StyledIconButton from './IconButton.style';
-import { MouseEventHandler } from 'react';
+import { IconButtonProps } from '@mui/material';
 
 type IconBtnProps = {
   icontype: 'delete' | 'close' | 'logout' | 'download' | 'edit'
-  onClick?:MouseEventHandler<HTMLButtonElement>;
 }
 
-export default function IconBtn({icontype, onClick}: IconBtnProps) {
+type combineProps = IconBtnProps & IconButtonProps 
+
+export default function IconBtn({icontype, ...props}: combineProps) {
   switch(icontype){
     case 'delete':
       return (
-        <StyledIconButton aria-label="close" onClick={onClick}>
+        <StyledIconButton aria-label="close" {...props}>
           <DeleteIcon />
         </StyledIconButton>
       )
     case 'close':
       return (
-        <StyledIconButton aria-label="close" onClick={onClick}>
+        <StyledIconButton aria-label="close" {...props}>
           <CloseIcon />
         </StyledIconButton>
       )
     case 'logout':
       return (
-        <StyledIconButton aria-label="logout" onClick={onClick}>
+        <StyledIconButton aria-label="logout" {...props}>
           <ExitToAppIcon />
         </StyledIconButton>
       )
     case 'download':
       return (
-        <StyledIconButton aria-label="download" onClick={onClick}>
-          <ExitToAppIcon />
+        <StyledIconButton aria-label="download" {...props}>
+          <DownloadIcon />
         </StyledIconButton>
       )
     case 'edit':
       return (
-        <StyledIconButton aria-label="edit" onClick={onClick}>
+        <StyledIconButton aria-label="edit" {...props}>
           <EditIcon />
         </StyledIconButton>
       )


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

MUI 버튼 기본 props 커스텀 버튼에 반영

## 📋 작업 내용

- 각각 원래의 MUI 컴포넌트에 들어있는 props 속성을 커스텀 된 컴포넌트 버튼에서도 사용할 수 있도록 수정함
- 다운로드 버튼의 경우 아이콘이 로그아웃 버튼으로 삽입되어있어 다운로드 아이콘으로 수정

## 🔧 변경 사항

위와 같음

## 📄 기타

수정사항, 필요한 사항 생기면 말씀 주세요
