### PR TITLE
[feature] 급여 상세 내역 페이지 컴포넌트 분리

### DIFF
--- a/src/pages/salaryDetail/MoveMonth.style.ts
+++ b/src/pages/salaryDetail/MoveMonth.style.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const Movemonth = styled.div`
+  height:30px;
+  margin-top:1.3rem;
+  text-align:center;
+
+  .css-i4bv87-MuiSvgIcon-root{
+      height:0.8em;
+  }
+
+  .up-date{
+    font-weight:var(--font-weight-bold);
+    font-size:1.3rem;
+    margin:0 5px;
+
+    .css-i4bv87-MuiSvgIcon-root{
+      height:0.7em;
+    }
+  }
+`;

--- a/src/pages/salaryDetail/MoveMonth.tsx
+++ b/src/pages/salaryDetail/MoveMonth.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import dayjs, { Dayjs } from "dayjs";
+import * as Styled from './MoveMonth.style';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+
+export default function MoveMonth(){
+  const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs('2024-07-25'));
+  const handlePrevMonth = () => {
+    setCurrentMonth(currentMonth.subtract(1, 'month'));
+  };
+  
+  const handleNextMonth = () => {
+    setCurrentMonth(currentMonth.add(1, 'month'));
+  };
+
+  return(
+    <Styled.Movemonth>
+      <ChevronLeftIcon onClick={handlePrevMonth} style={{ cursor: 'pointer' }} />
+        <span className="up-date">
+          {currentMonth.format('YYYY.MM')}
+          <CalendarTodayIcon />
+        </span>
+      <ChevronRightIcon onClick={handleNextMonth} style={{ cursor: 'pointer' }} />
+    </Styled.Movemonth>
+  )
+}

--- a/src/pages/salaryDetail/SalaryCard.style.ts
+++ b/src/pages/salaryDetail/SalaryCard.style.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components"
+
+export const Container = styled.div`
+  text-align:center;
+  font-size:1.6rem;
+
+  .bold {
+    font-weight:var(--font-weight-bold);
+  }
+  & > div {
+    background: linear-gradient(180deg, var(--color-pri), #9FA1AB);
+    color: var(--color-white);
+    padding-bottom:5rem;
+  }
+`;
+
+export const ItemWrapper = styled.div`
+  display:flex;
+  justify-content: space-between;
+  font-weight:var(--font-weight-bold);
+
+  .pay{
+    padding-top:1rem;
+    font-size:1.2rem;
+  }
+  .pay > h5,
+  .pay > h3{
+  font-weight:var(--font-weight-bold);
+  }
+`;

--- a/src/pages/salaryDetail/SalaryCard.tsx
+++ b/src/pages/salaryDetail/SalaryCard.tsx
@@ -1,0 +1,28 @@
+import * as Styled from './SalaryCard.style';
+import CardBox from "../../components/cardBox/CardBox";
+
+type salaryData = {
+  id: number;
+  name: string;
+  realpay: string;
+  payday: string;
+}
+
+export default function SalaryCard({id, name, realpay, payday}:salaryData){
+  return(
+  <Styled.Container>
+  <CardBox key={id}>
+    <span className="bold">{name}</span> 님의 노고에 감사드립니다.
+      <hr />
+      <Styled.ItemWrapper>
+        <div className="pay"><h5>실수령액</h5></div>
+          <div className="pay"><h3>{realpay}원</h3></div>
+      </Styled.ItemWrapper><hr/>
+      <Styled.ItemWrapper>
+        <div className="pay">급여지급일</div>
+          <div className="pay">{payday}</div>
+      </Styled.ItemWrapper>
+  </CardBox>
+  </Styled.Container>
+  )
+}

--- a/src/pages/salaryDetail/SalaryDeatil.style.ts
+++ b/src/pages/salaryDetail/SalaryDeatil.style.ts
@@ -34,34 +34,6 @@ align-items:center;
 gap: 1rem; 
 `;
 
-export const Container = styled.div`
-  text-align:center;
-  font-size:1.6rem;
-
-  .bold {
-    font-weight:var(--font-weight-bold);
-  }
-  & > div {
-    background: linear-gradient(180deg, var(--color-pri), #9FA1AB);
-    color: var(--color-white);
-    padding-bottom:5rem;
-  }
-`
-export const ItemWrapper = styled.div`
-  display:flex;
-  justify-content: space-between;
-  font-weight:var(--font-weight-bold);
-
-  .pay{
-    padding-top:1rem;
-    font-size:1.2rem;
-  }
-  .pay > h5,
-  .pay > h3{
-  font-weight:var(--font-weight-bold);
-  }
-`;
-
 export const ListWrapper = styled.div<{ type?:string }>`
   display:flex;
   justify-content: space-between;
@@ -76,24 +48,4 @@ export const ListWrapper = styled.div<{ type?:string }>`
 
 export const Info = styled.div`
   margin-top:2.3rem;
-`;
-
-export const Movemonth = styled.div`
-  height:30px;
-  margin-top:1.3rem;
-  text-align:center;
-
-  .css-i4bv87-MuiSvgIcon-root{
-      height:0.8em;
-  }
-
-  .up-date{
-    font-weight:var(--font-weight-bold);
-    font-size:1.3rem;
-    margin:0 5px;
-
-    .css-i4bv87-MuiSvgIcon-root{
-      height:0.7em;
-    }
-  }
 `;

--- a/src/pages/salaryDetail/SalaryDetail.tsx
+++ b/src/pages/salaryDetail/SalaryDetail.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from "react";
 import Btn from "../../components/button/Button";
 import IconBtn from "../../components/iconButton/IconButton";
-import * as Styled from './SalaryDetail.style';
+import * as Styled from './SalaryDeatil.style';
 import Heading from "../../components/Heading/Heading";
-import CardBox from "../../components/cardBox/CardBox";
-import dayjs, { Dayjs } from "dayjs";
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import dayjs from "dayjs";
+import SalaryCard from "./SalaryCard";
+import MoveMonth from "./MoveMonth";
 
 interface SalaryDetailItem {
   label: string;
@@ -54,16 +51,6 @@ const ListWrapper = ({ details }: { details: SalaryDetailItem[] }) => {
 }
 
 export default function SalaryDetail() {
-  const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs('2024-07-25'));
-
-  const handlePrevMonth = () => {
-    setCurrentMonth(currentMonth.subtract(1, 'month'));
-  };
-
-  const handleNextMonth = () => {
-    setCurrentMonth(currentMonth.add(1, 'month'));
-  };
-
   return (
     <>
       <Styled.Header>
@@ -72,42 +59,26 @@ export default function SalaryDetail() {
           <Heading title="급여명세서" />
         </Styled.LSection>
         <Styled.RSection>
-          <Btn label='정정신청' />
+          <Btn size="lg" label='정정신청' />
           <IconBtn icontype="download" />
         </Styled.RSection>
       </Styled.Header>
       <Styled.Listline />
-      <Styled.Movemonth>
-        <ChevronLeftIcon onClick={handlePrevMonth} style={{ cursor: 'pointer' }} />
-        <span className="up-date">
-          {currentMonth.format('YYYY.MM')}
-          <CalendarTodayIcon />
-        </span>
-        <ChevronRightIcon onClick={handleNextMonth} style={{ cursor: 'pointer' }} />
-      </Styled.Movemonth>
-      <Styled.Container>
-        {SalaryData.map((el) => (
-          <CardBox key={el.id}>
-            <span className="bold">{el.name}</span> 님의 노고에 감사드립니다.
-            <hr />
-            <Styled.ItemWrapper>
-              <div className="pay"><h5>실수령액</h5></div>
-              <div className="pay"><h3>{el.realpay}원</h3></div>
-            </Styled.ItemWrapper>
-            <hr />
-            <Styled.ItemWrapper>
-              <div className="pay">급여지급일</div>
-              <div className="pay">{el.payday}</div>
-            </Styled.ItemWrapper>
-          </CardBox>
-        ))}
-      </Styled.Container>
+      <MoveMonth/>
       {SalaryData.map((el) => (
-        <Styled.Info key={el.id}>
-          <Styled.Listline />
-          <ListWrapper details={el.details} />
-          <Styled.Listline />
-        </Styled.Info>
+        <div key={el.id}>
+          <SalaryCard
+            id={el.id} 
+            name={el.name} 
+            realpay={el.realpay} 
+            payday={el.payday}
+          />
+          <Styled.Info>
+            <Styled.Listline />
+            <ListWrapper details={el.details} />
+            <Styled.Listline />
+          </Styled.Info>
+        </div>
       ))}
     </>
   );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여 상세 내역 페이지 컴포넌트 분리

## 📋 작업 내용

- 급여 상세내역 카드 컴포넌트 분리
- 월별 상세 확인 버튼 컴포넌트 분리
- styled.tsx 확장자 ts로 변경

## 🔧 변경 사항

상세내역 카드, 월별 이동 버튼 컴포넌트로 불러와서 상세내역 페이지에 적용

## 📄 기타

