### PR TITLE
Fix modal component, remove default close button and default open button

### DIFF
--- a/src/components/modal/BasicModal.tsx
+++ b/src/components/modal/BasicModal.tsx
@@ -1,12 +1,9 @@
-import Button from '@mui/material/Button';
 import Modal from '@mui/material/Modal';
 import NavBar from '../nav/NavBar';
-import { IF } from '../../utils/IFElse';
 import React from 'react';
-import { CloseButton } from './CloseButton';
-import { useBasicModal } from './useBasicModal';
+import { ModalProps } from '@mui/material';
 
-interface BasicModalProps {
+interface BasicModalProps extends Omit<ModalProps, 'children'> {
   children?: React.ReactElement;
   modalOpenButton?: React.ReactElement;
   modalCloseButton?: React.ReactNode;
@@ -18,28 +15,13 @@ export default function BasicModal({
   modalCloseButton,
   ...props
 }: BasicModalProps) {
-  const { open, handleOpen, handleClose } = useBasicModal();
-
   return (
     <div>
-      <IF condition={!!modalOpenButton}>
-        <IF.Then>{modalOpenButton}</IF.Then>
-        <IF.Else>
-          <Button onClick={handleOpen}>Open modal</Button>
-        </IF.Else>
-      </IF>
-      <Modal {...props} open={open} onClose={handleClose}>
+      {modalOpenButton}
+      <Modal {...props}>
         <>
-          <IF condition={!!children}>
-            <IF.Then>{children}</IF.Then>
-            <IF.Else>""</IF.Else>
-          </IF>
-          <IF condition={!!modalCloseButton}>
-            <IF.Then>{modalCloseButton}</IF.Then>
-            <IF.Else>
-              <CloseButton handleClose={handleClose} />
-            </IF.Else>
-          </IF>
+          {children}
+          {modalCloseButton}
           <NavBar />
         </>
       </Modal>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- Fix modal component, remove default close button and default open button
- 모달 안에 기본 버튼들을 삭제함.

### 매개 변수 설명

#### children
- children: react element, 모달 컴포넌트 안에 들어가는 내용들

#### useBasicModal.tsx  모달 상태 변수들
- **open**: 열기, 닫기 관련 리액트 state 상태 변수
- modalOpenButton: 열기 버튼, **handleOpen** 상태 관리훅을 필요로함.
- modalCloseButton: 닫기 버튼, **handleClose** 상태 관리훅을 필요로함.

### 사용방법.


```js
import { useBasicModal } from "주소";

const {handleOpen, handleClose, open} = useBasicModal();
      <BasicModal open={open} modalOpenButton={<button onClick={handleOpen}>open</button>}   modalCloseButton={<button onClick={handleClose}>close</button>}>
        <styled.ModalWrapper>
          <styled.PageTitle>급여 정정신청</styled.PageTitle>
          <styled.ModalTitle>03월 급여 정정 신청</styled.ModalTitle>
          <SelectBox
            labelId="labelCate"
            id="cate"
            label="카테고리"
            menuItems={[
              { text: '주말 / 공휴일 근무 수당', value: 'cate1' },
              { text: '야간 근무 수당(22:00-06:00)', value: 'cate2' },
              { text: '연차 누락', value: 'cate3' },
              { text: '경비 처리', value: 'cate4' },
            ]}
          />
          <TextInputField label="제목" variant="outlined" />
          <SDataPicker dateType="range" />
        </styled.ModalWrapper>
      </BasicModal>

```



```js
export default function BasicModal({
  children,
  modalOpenButton,
  modalCloseButton,
  ...props
}: BasicModalProps) {
  return (
    <div>
      {modalOpenButton}
      <Modal {...props}>
        <>
          {children}
          {modalCloseButton}
          <NavBar />
        </>
      </Modal>
    </div>
  );
}

```