### PR TITLE
[Feature, Refactor] 급여 상세내역 페이지 컴포넌트 분리

### DIFF
--- a/src/pages/salaryDetail/ListWrapper.tsx
+++ b/src/pages/salaryDetail/ListWrapper.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import * as Styled from './SalaryDetail.style';
+
+type SalaryDetailItem = {
+    label:string;
+    value:string;
+    type?: 'main' | 'sub'
+}
+
+type ListWrapperProps = {
+    details:SalaryDetailItem[];
+}
+
+export default function ListWrapper({details}:ListWrapperProps) {
+    return (
+    <>     
+    {details.map((item, index)=>
+      <React.Fragment key={index}>
+        <Styled.ListWrapper type={item.type}>
+          <div>{item.label}</div>
+          <div>{item.value}원</div>
+        </Styled.ListWrapper>
+        {item.type === 'main' && index !== details.length - 1 && (
+          <Styled.Thinline />
+        )}
+        {item.type === 'sub' && index !== details.length - 1 &&
+          (<Styled.Listline/>)
+        }
+        </React.Fragment>
+        )}
+      </>
+    );
+  }

--- a/src/pages/salaryDetail/MoveMonth.tsx
+++ b/src/pages/salaryDetail/MoveMonth.tsx
@@ -1,18 +1,27 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import * as Styled from './MoveMonth.style';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import { useNavigate } from "react-router-dom";
 
-export default function MoveMonth(){
-  const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs('2024-07-25'));
+type MoveMonthProps = {
+  date:string;
+  id:number
+}
+
+export default function MoveMonth({date, id}:MoveMonthProps){
+  const navigate=useNavigate()
+  const [currentMonth, setCurrentMonth] = useState<Dayjs>(dayjs(date));
   const handlePrevMonth = () => {
     setCurrentMonth(currentMonth.subtract(1, 'month'));
+    navigate(`/salary-detail/${id-1}`)
   };
   
   const handleNextMonth = () => {
     setCurrentMonth(currentMonth.add(1, 'month'));
+    navigate(`/salary-detail/${id+1}`)
   };
 
   return(

--- a/src/pages/salaryDetail/SalaryDetail.style.ts
+++ b/src/pages/salaryDetail/SalaryDetail.style.ts
@@ -38,10 +38,10 @@ export const ListWrapper = styled.div<{ type?:string }>`
   display:flex;
   justify-content: space-between;
   gap: 1rem;
-  padding:1rem;
+  padding:1.4rem 1rem;
 
   div{
-    font-size: ${props => props.type === 'main' ? '1rem' : '0.875rem'};
+    font-size: ${props => props.type === 'main' ? '1.4rem' : '1.2rem'};
     font-weight: ${props => props.type === 'main' ? 'bold' : 'normal'};
   }
 `;

--- a/src/pages/salaryDetail/SalaryDetail.tsx
+++ b/src/pages/salaryDetail/SalaryDetail.tsx
@@ -1,10 +1,12 @@
+import { useNavigate,useParams } from "react-router-dom";
 import Btn from "../../components/button/Button";
 import IconBtn from "../../components/iconButton/IconButton";
-import * as Styled from './SalaryDeatil.style';
+import * as Styled from './SalaryDetail.style';
 import Heading from "../../components/Heading/Heading";
 import dayjs from "dayjs";
 import SalaryCard from "./SalaryCard";
 import MoveMonth from "./MoveMonth";
+import ListWrapper from "./ListWrapper";
 
 interface SalaryDetailItem {
   label: string;
@@ -25,6 +27,34 @@ const SalaryData: SalaryDataItem[] = [
     id: 1,
     name: '김지훈',
     realpay: '3,199,260',
+    payday: dayjs('2024-05-25').format('YYYY.MM.DD'),
+    details: [
+      { label: '지급내역', value: '3,500,000', type: 'main' },
+      { label: '기본급', value: '3,500,000', type: 'sub' },
+      { label: '공제내역', value: '300,700', type: 'main' },
+      { label: '국민연금', value: '150,000', type: 'sub' },
+      { label: '수당내역', value: '10,500,000', type: 'main' },
+      { label: '인센티브', value: '10,500,000', type: 'sub' },
+    ]
+  },
+  {
+    id: 2,
+    name: '김지훈',
+    realpay: '3,199,260',
+    payday: dayjs('2024-06-25').format('YYYY.MM.DD'),
+    details: [
+      { label: '지급내역', value: '3,500,000', type: 'main' },
+      { label: '기본급', value: '3,500,000', type: 'sub' },
+      { label: '공제내역', value: '300,700', type: 'main' },
+      { label: '국민연금', value: '150,000', type: 'sub' },
+      { label: '수당내역', value: '10,500,000', type: 'main' },
+      { label: '인센티브', value: '10,500,000', type: 'sub' },
+    ]
+  },
+  {
+    id: 3,
+    name: '김지훈',
+    realpay: '3,199,260',
     payday: dayjs('2024-07-25').format('YYYY.MM.DD'),
     details: [
       { label: '지급내역', value: '3,500,000', type: 'main' },
@@ -37,49 +67,52 @@ const SalaryData: SalaryDataItem[] = [
   }
 ];
 
-const ListWrapper = ({ details }: { details: SalaryDetailItem[] }) => {
-  return (
-    <>
-      {details.map((item, index) => (
-        <Styled.ListWrapper key={index} type={item.type}>
-          <div>{item.label}</div>
-          <div>{item.value}원</div>
-        </Styled.ListWrapper>
-      ))}
-    </>
-  );
-}
+SalaryData.sort((a,b)=>b.id-a.id)
 
 export default function SalaryDetail() {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>();
+  const detailData = id ? SalaryData.find(data => data.id === parseInt(id)) : undefined
+
+  if (!detailData) {
+    return <div>급여 명세서가 없습니다.</div>;
+  }
+
+  const handleCloseButton = () =>{
+    navigate('/payments')
+  }
+
+  const handleDownload = () =>{
+
+  }
+  
   return (
     <>
       <Styled.Header>
         <Styled.LSection>
-          <IconBtn icontype="close" />
+          <IconBtn icontype="close" onClick={handleCloseButton}/>
           <Heading title="급여명세서" />
         </Styled.LSection>
         <Styled.RSection>
           <Btn size="lg" label='정정신청' />
-          <IconBtn icontype="download" />
+          <IconBtn icontype="download" onClick={handleDownload} />
         </Styled.RSection>
       </Styled.Header>
       <Styled.Listline />
-      <MoveMonth/>
-      {SalaryData.map((el) => (
-        <div key={el.id}>
-          <SalaryCard
-            id={el.id} 
-            name={el.name} 
-            realpay={el.realpay} 
-            payday={el.payday}
-          />
-          <Styled.Info>
-            <Styled.Listline />
-            <ListWrapper details={el.details} />
-            <Styled.Listline />
-          </Styled.Info>
-        </div>
-      ))}
+      <MoveMonth id = {detailData.id} date={detailData.payday}/>
+      <div key={detailData.id}>
+        <SalaryCard
+          id={detailData.id} 
+          name={detailData.name} 
+          realpay={detailData.realpay} 
+          payday={detailData.payday}
+        />
+        <Styled.Info>
+          <Styled.Listline />
+          <ListWrapper details={detailData.details} />
+          <Styled.Listline />
+        </Styled.Info>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여 상세내역 페이지 컴포넌트 분리 및 기능 추가

## 📋 작업 내용

- 급여 상세내역 페이지 컴포넌트 분리, 목록 글자 크기 수정 및 구분선 추가
- 급여명세서 확인 기능 추가

## 🔧 변경 사항

- move 버튼 클릭 시 이전 달, 다음 달의 명세서를 확인할 수 있도록 수정
- 목록 클릭 시 해당하는 달의 명세서를 확인할 수 있도록 수정
- 다음 달, 이전 달 버튼을 눌렀을 때 명세서가 없으면 명세서가 없음을 알리는 페이지 노출 


## 📄 기타

