### PR TITLE
feat: navbar focus, 현재 페이지에 해당하는 네비게이션 버튼에 포커스를 준다

### DIFF
--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -1,13 +1,26 @@
 import NavButton from './NavButton';
 import * as Styled from './NavBar.style';
 import { navbarItems } from './NavLinks';
+import { useNavBar } from './useNavbar';
+import { useLocation } from 'react-router-dom';
 
 export default function NavBar() {
+  const location = useLocation();
+  const { selected, setSelected } = useNavBar(location.pathname);
+
+  console.log(location.pathname);
   return (
     <Styled.NavBarWrapper>
       <Styled.MyToolbar>
-        {navbarItems.map((page) => (
-          <NavButton key={page.name} name={page.name} Icon={page.icon} link={page.link} />
+        {navbarItems.map((navItem) => (
+          <NavButton
+            setSelected={setSelected}
+            selected={selected}
+            key={navItem.name}
+            name={navItem.name}
+            Icon={navItem.icon}
+            link={navItem.link}
+          />
         ))}
       </Styled.MyToolbar>
     </Styled.NavBarWrapper>

--- a/src/components/nav/NavButton.style.tsx
+++ b/src/components/nav/NavButton.style.tsx
@@ -4,7 +4,7 @@ import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { Link } from 'react-router-dom';
 
-export const MUIButton = muiStyled(Button)`
+export const MUIButton = muiStyled(Button)<{ selected: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -14,13 +14,14 @@ export const MUIButton = muiStyled(Button)`
   flex: 1;
   height: 80px;
   min-width: 0;
-  
+  background-color: ${(props) => (props.selected ? 'var(--color-pri)' : 'transparent')};
+  color: ${(props) => (props.selected ? '#fff' : '#333')};
+
   &:hover,
   &:active {
     background-color: var(--color-pri);
     color: #fff;
   }
-  color: #333;
 `;
 
 export const TextBox = muiStyled(Box)`
@@ -52,4 +53,6 @@ export const LinkRoute = styled(Link)`
   position: absolute;
   text-decoration: none;
   color: inherit;
+  width: 100%;
+  height: 100%;
 `;

--- a/src/components/nav/NavButton.tsx
+++ b/src/components/nav/NavButton.tsx
@@ -1,15 +1,17 @@
 import * as Styled from './NavButton.style';
 
 interface NavButtonProps {
+  selected: string;
   name: string;
   Icon: React.ReactElement;
   link: string;
+  setSelected: (value: string) => void;
 }
 
-export default function NavButton({ name, Icon, link }: NavButtonProps) {
+export default function NavButton({ selected, name, Icon, link, setSelected }: NavButtonProps) {
   return (
-    <Styled.MUIButton key={name}>
-      <Styled.LinkRoute to={`${link}`}>
+    <Styled.MUIButton key={name} selected={selected === link}>
+      <Styled.LinkRoute onClick={() => setSelected(link)} to={`${link}`}>
         <Styled.IconWrapper>{Icon}</Styled.IconWrapper>
         <Styled.TextBox>{name}</Styled.TextBox>
       </Styled.LinkRoute>

--- a/src/components/nav/useNavbar.tsx
+++ b/src/components/nav/useNavbar.tsx
@@ -1,0 +1,6 @@
+import { useState } from 'react';
+
+export function useNavBar(selectedItem: string) {
+  const [selected, setSelected] = useState(selectedItem);
+  return { selected, setSelected };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import GlobalStyle from './styles/GlobalStyle.tsx';
-
-import { RouterProvider } from 'react-router-dom';
-import { router } from './router.tsx';
-
-
 import App from './App.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
- 현재 페이지에 해당하는 네비게이션 버튼에 포커스를 준다.
- src/components/nav/NavBar.tsx, src/components/nav/NavButton.style.tsx, src/components/nav/NavButton.tsx, src/components/nav/useNavbar.tsx, src/main.tsx 수정
Github issue #36

# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
