### PR TITLE
Style : 급여정산 페이지 스타일 수정

### DIFF
--- a/src/pages/salaryDetail/ListWrapper.tsx
+++ b/src/pages/salaryDetail/ListWrapper.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
 import * as Styled from './SalaryDetail.style';
+import {SalaryDetailItem} from '../salaryList/api/fetchSalaryInfo';
 
-type SalaryDetailItem = {
-    label:string;
-    value:string;
-    type?: 'main' | 'sub'
+interface ListWrapperItems {
+  details: SalaryDetailItem[]
 }
 
-type ListWrapperProps = {
-    details:SalaryDetailItem[];
-}
-
-export default function ListWrapper({details}:ListWrapperProps) {
+export default function ListWrapper({details}:ListWrapperItems) {
     return (
     <>     
     {details.map((item, index)=>
       <React.Fragment key={index}>
-        <Styled.ListWrapper type={item.type}>
+        <Styled.ListWrapper type={item.type} content={item.content}>
           <div>{item.label}</div>
-          <div>{item.value}원</div>
+          <div className='price'>{item.value} 원</div>
         </Styled.ListWrapper>
         {item.type === 'main' && index !== details.length - 1 && (
           <Styled.Thinline />

--- a/src/pages/salaryDetail/SalaryCard.style.ts
+++ b/src/pages/salaryDetail/SalaryCard.style.ts
@@ -8,7 +8,7 @@ export const Container = styled.div`
     font-weight:var(--font-weight-bold);
   }
   & > div {
-    background: linear-gradient(180deg, var(--color-pri), #9FA1AB);
+    background: var(--color-pri-white);
     color: var(--color-white);
     padding-bottom:5rem;
   }
@@ -28,3 +28,7 @@ export const ItemWrapper = styled.div`
   font-weight:var(--font-weight-bold);
   }
 `;
+
+export const LgFont = styled.span`
+  font-size:25px;
+`

--- a/src/pages/salaryDetail/SalaryCard.tsx
+++ b/src/pages/salaryDetail/SalaryCard.tsx
@@ -16,7 +16,7 @@ export default function SalaryCard({id, name, realpay, payday}:salaryData){
       <hr />
       <Styled.ItemWrapper>
         <div className="pay"><h5>실수령액</h5></div>
-          <div className="pay"><h3>{realpay}원</h3></div>
+          <div className="pay"><h3><Styled.LgFont>{realpay}</Styled.LgFont> 원</h3></div>
       </Styled.ItemWrapper><hr/>
       <Styled.ItemWrapper>
         <div className="pay">급여지급일</div>

--- a/src/pages/salaryDetail/SalaryDetail.style.ts
+++ b/src/pages/salaryDetail/SalaryDetail.style.ts
@@ -14,7 +14,7 @@ export const Header = styled.div`
 
 export const Listline = styled.div`
   background-color:var(--border-pri);
-  height:0.1rem;
+  height:0.05rem;
 `;
 
 export const Thinline = styled.div`
@@ -34,15 +34,23 @@ export const RSection = styled.div`
   gap: 1rem; 
 `;
 
-export const ListWrapper = styled.div<{ type?:string }>`
+export const ListWrapper = styled.div<{ type?:string, content?:string}>`
   display:flex;
   justify-content: space-between;
   gap: 1rem;
-  padding:1.4rem 1rem;
+  padding:2rem 1rem;
+  box-sizing:border-box;
   
   div{
     font-size: ${props => props.type === 'main' ? '1.4rem' : '1.2rem'};
     font-weight: ${props => props.type === 'main' ? 'bold' : 'normal'};
+  }
+  .price{
+    color: ${props => 
+      props.content === 'pension' ? '#039C00' :
+      props.content === 'deduction' ? '#CC4846' :
+      props.content === 'pay' ? 'var(--color-pri)' : 
+      'var(--color-black)'}
   }
 `;
 

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -2,11 +2,10 @@ import { useNavigate, useParams } from "react-router-dom";
 import Btn from "../../components/button/Button";
 import IconBtn from "../../components/iconButton/IconButton";
 import * as Styled from './SalaryDetail.style';
-import Heading from "../../components/Heading/Heading";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 import React, { useRef } from "react";
-import { SalaryDataItem} from "../salaryList/api/fetchSalaryInfo";
+import {SalaryDataItem} from '../salaryList/api/fetchSalaryInfo';
 import useSalaryDetails from "../salaryList/useSalaryDetails";
 import MoveMonth from "./MoveMonth";
 import SalaryCard from "./SalaryCard";
@@ -63,7 +62,7 @@ export default function SalaryDetailPage() {
           <Styled.Header>
             <Styled.LSection>
               <IconBtn icontype="close" onClick={handleCloseButton} />
-                <Heading title="급여명세서" />
+                <h2>급여명세서</h2>
               </Styled.LSection>
               <Styled.RSection>
               <Btn size="lg" label='정정신청' onClick={handleApply} />
@@ -81,7 +80,7 @@ export default function SalaryDetailPage() {
                 />
                 <Styled.Info>
                   <Styled.Listline />
-                  <ListWrapper details={salaryData.details} />
+                  <ListWrapper details={salaryData.details}/>
                   <Styled.Listline />
                 </Styled.Info>
           </div>

--- a/src/pages/salaryList/NoticeCard.style.ts
+++ b/src/pages/salaryList/NoticeCard.style.ts
@@ -2,12 +2,12 @@ import styled from "styled-components";
 
 export const SalaryCardBox = styled.div`
   color:var(--color-black);
-  padding: 2rem;
+  background-color:var(--color-white);
+  padding: 3rem;
   margin: 1rem;
   border-radius:0.8rem;
   border: 3px solid var(--color-pri);
   margin: 2rem auto;
-  text-align:center;
   box-sizing:border-box;
 
   h2{

--- a/src/pages/salaryList/NoticeCard.style.ts
+++ b/src/pages/salaryList/NoticeCard.style.ts
@@ -3,18 +3,24 @@ import styled from "styled-components";
 export const SalaryCardBox = styled.div`
   color:var(--color-black);
   background-color:var(--color-white);
-  padding: 3rem;
+  padding: 1.2rem 4rem 2rem 4rem;
   margin: 1rem;
-  border-radius:0.8rem;
-  border: 3px solid var(--color-pri);
+  border-radius:2rem;
+  box-shadow: 0px 1px 0px 0.2px var(--border-pri);
   margin: 2rem auto;
   box-sizing:border-box;
 
+  .imoge{
+    font-size:60px;
+    text-align:end;
+  }
+
   h2{
-    line-height:5rem;
+    line-height:4rem;
+    font-weight:var(--font-weight-semi);
   }
   h3{
-    font-weight:var(--font-weight-semibold);
+    font-weight:var(--font-weight-semi);
     margin-bottom:15px;
   }
 `;

--- a/src/pages/salaryList/NoticeCard.tsx
+++ b/src/pages/salaryList/NoticeCard.tsx
@@ -13,10 +13,11 @@ export default function NoticeCard({ date, day, button = false, label, onClick }
   return (
     <Styled.SalaryCardBox>
       <h2>
-        <Styled.Orangetxt>{date}</Styled.Orangetxt>급여 명세서
+        <Styled.Orangetxt>{date}</Styled.Orangetxt>급여명세서
       </h2>
+      <h6 className='imoge'>✉️</h6>
       <h3>
-        <p>정정 신청 기간입니다.</p>
+        <p>정정 신청 기간입니다.</p> 
         <p>
           <Styled.Orangetxt>{day}</Styled.Orangetxt>까지 신청해주세요.
         </p>

--- a/src/pages/salaryList/SalaryList.style.ts
+++ b/src/pages/salaryList/SalaryList.style.ts
@@ -29,13 +29,13 @@ export const Grayline = styled.div`
 `;
 
 export const ListCardBox = styled.div<{$state:boolean}>`
-  color:var(--color-black);
   background-color:var(--color-white);
-  padding: 1.7rem;
+  color:var(--color-black);
+  padding: 1.5rem 2rem 2rem 2rem;
   border-radius:1rem;
-  margin: 1rem auto;
+  margin: 1.5rem auto;
   display:flex;
-  max-height:2.3rem;
+  height:2.5rem;
   justify-content:space-between;
   border:${({$state})=> $state === true ? 
     '1px solid var(--color-pri)' : 
@@ -50,17 +50,18 @@ export const ListCardBox = styled.div<{$state:boolean}>`
   }
 `;
 
-export const List = styled.div`
+export const List = styled.div<{$state:boolean}>`
   display: flex;
   flex-direction: column;
   justify-content: center;
   & > .title {
-    font-weight: var(--font-weight-semibold);
+    font-weight: ${({$state}) => $state === true? 'var(--font-weight-bold)' : 'var(font-weight-semibold)'};
+    line-height: 3.2rem;
     font-size: 1.5rem;
   }
   & > .date {
     font-size: 13px;
-    color: var(--color-gray);
+    color: ${({$state}) => $state === true? 'var(--font-pri)' : 'var(--font-sec)'};
     text-align:left;
   }
 `;

--- a/src/pages/salaryList/SalaryList.style.ts
+++ b/src/pages/salaryList/SalaryList.style.ts
@@ -30,8 +30,9 @@ export const Grayline = styled.div`
 
 export const ListCardBox = styled.div<{$state:boolean}>`
   color:var(--color-black);
-  padding: 1.5rem;
-  border-radius:0.5rem;
+  background-color:var(--color-white);
+  padding: 1.7rem;
+  border-radius:1rem;
   margin: 1rem auto;
   display:flex;
   max-height:2.3rem;
@@ -55,10 +56,10 @@ export const List = styled.div`
   justify-content: center;
   & > .title {
     font-weight: var(--font-weight-semibold);
-    font-size: 1.2rem;
+    font-size: 1.5rem;
   }
   & > .date {
-    font-size: 10px;
+    font-size: 13px;
     color: var(--color-gray);
     text-align:left;
   }

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -1,11 +1,11 @@
 import SelectBox from "../../components/selectBox/SelectBox";
 import Btn from "../../components/button/Button";
 import dayjs from "dayjs";
-import Heading from "../../components/Heading/Heading";
 import * as Styled from './SalaryList.style';
 import { useNavigate } from "react-router-dom";
 import NoticeCard from "./NoticeCard";
 import useSalaryDetails from "./useSalaryDetails";
+import Heading from "../../components/Heading/Heading";
 
 const years = [
   { value: '2021', text: '2021' },
@@ -27,7 +27,7 @@ export default function SalaryListPage(){
 
   const firstPayData = salaryList[0]
   const originDate = dayjs(firstPayData.payday,'YYYY.MM.DD')
-  const finalDate = originDate.format('YYYY년 MM월 ')
+  const finalDate = originDate.format('MM월 ')
   const finalDay = originDate.subtract(2,'day').format('DD일')
 
   const handleApplicationBtn = (id:number) => {
@@ -40,8 +40,7 @@ export default function SalaryListPage(){
 
   return(
     <Styled.Salary>
-      <Heading title="급여내역"/>
-      <Styled.Grayline/>
+      <Heading title="급여정산"/>
       <NoticeCard date={finalDate} day={finalDay}/>
         <Styled.YearSelect>
         <SelectBox 
@@ -54,15 +53,15 @@ export default function SalaryListPage(){
         {salaryList.map((el)=>
           (<Styled.ListCardBox key={el.id} $state={el.state} 
             onClick={()=>{handleApplicationBtn(el.id)}}>
-            <Styled.List>
+            <Styled.List $state={el.state}>
             <span className="title">{el.title}</span>
             <span className="date">{el.state === true ? '지급예정' : el.payday}</span>
             </Styled.List>
             <Styled.Btn>
               {el.state === true ? 
-              <Btn round ='true' label='신청가능'/> 
+              <Btn round ='true' btntype='outlined' size='lg' label='신청가능'/> 
               : 
-              <Btn round='true' disabled label='지급완료'/> 
+              <Btn round='true' disabled size='lg' label='지급완료'/> 
               }
             </Styled.Btn>
         </Styled.ListCardBox>))}

--- a/src/pages/salaryList/api/fetchSalaryInfo.ts
+++ b/src/pages/salaryList/api/fetchSalaryInfo.ts
@@ -5,6 +5,7 @@ export interface SalaryDetailItem {
   label: string;
   value: string;
   type?: 'main' | 'sub';
+  content?:string;
 }
 
 export interface SalaryDataItem {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여정산 페이지, 급여명세서 페이지 스타일 수정

## 📋 작업 내용

- 급여 정산 페이지 내 공지 카드 파란 테두리 삭제
- 각 카드 border-raius 값, padding 값 수정
- 급여명세서 페이지 heading 삭제, h2급여명세서/h2로 변경
- 급여명세서 페이지 카드 색상 변경
- 지급내역, 공제내역, 수당내역 글자 색상 변경

## 🔧 변경 사항

작업내용과 같음

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/2f7fdf92-3aa3-4f45-92e8-54a5fbfbfd23)
- 배경이 회색으로 바뀔 경우
![image](https://github.com/user-attachments/assets/6d73fd12-b216-4f80-a5ea-5f17c9192644)


## 📄 기타

회색 배경의 경우 아직 globalStyle 쪽에서 body 색상을 수정하지 않은 상태라 임의로 제 브랜치에서 배경색만 바꿔서 적용해봤습니다. 어떤 배경이 더 나으신가욥,,
회색으로 배경이 바뀌게 될 경우 AppLayout쪽에서 Header 레이아웃을 추가하고 Heading을 그쪽으로 빼는게 MainContent쪽에 padding 값을 주거나 배경 색깔을 바꿀 때 편할 것 같아요! 지금 회색 배경의 경우 MainContent padding 값을 빼둔 상태라 양옆 여백이 사라진 상태입니다


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Updated the visual presentation of salary details and list pages, enhancing readability and user experience. Changes include modifications to font sizes, colors, padding, borders, and text content.
- New Feature: Introduced a new 'price' CSS class for specific text color settings in salary display.
- Refactor: Adjusted the `ListWrapper` component and `SalaryDetailItem` interface to accommodate an optional `content` field, providing more flexibility in displaying salary information.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->