### PR TITLE
Feat: 대시보드 새 디자인으로 UI 수정

### DIFF
--- a/src/components/cardBox/CardBox.style.tsx
+++ b/src/components/cardBox/CardBox.style.tsx
@@ -2,8 +2,8 @@ import Box from '@mui/material/Box';
 import styled from 'styled-components';
 
 export const CardBox = styled(Box)`
-  padding: 20px;
+  padding: 2rem;
   border: 1px solid #eee;
   box-sizing: border-box;
-  border-radius: 10px;
+  border-radius: 2rem;
 `;

--- a/src/pages/Dashboard/CalendarCard.tsx
+++ b/src/pages/Dashboard/CalendarCard.tsx
@@ -13,10 +13,10 @@ export default function CalendarCard() {
 
 const CalendarCardWrapper = styled(CardBox)`
   display: flex;
+  border: 1px solid var(--border-sec);
   height: 19.5rem;
+  padding: 0;
   overflow: hidden;
-  background-color: var(--color-black);
+  position: relative;
   margin: 1rem 0;
-  border-radius: 30px;
-  color: var(--color-white);
 `;

--- a/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/pages/Dashboard/DashboardPage.tsx
@@ -1,48 +1,42 @@
-import Heading from '../../components/Heading/Heading';
 import ProfileCard from './ProfileCard';
 import CalendarCard from './CalendarCard';
 import NoticeCard from '../salaryList/NoticeCard';
 import dayjs from 'dayjs';
-import ListOutlinedIcon from '@mui/icons-material/ListOutlined';
 import { useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../store/store';
-import { ISchedule } from '../../slices/scheduleSlice';
+import SalaryCard from './SalaryCard';
+// import { useSelector } from 'react-redux';
+// import { RootState } from '../../store/store';
+// import { ISchedule } from '../../slices/scheduleSlice';
 
 function Dashboard() {
-  const originDate = dayjs('2024-03-25');
-  const finalDate = originDate.format('YYYY년 MM월 ');
-  const finalDay = originDate.subtract(0, 'day').format('DD일');
-  const navigate = useNavigate();
-  const schedules = useSelector((state: RootState) => state.schedules.schedules);
+  const currentDate = new Date();
+  const DueDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 25);
+  const originDate = dayjs(DueDate);
+  const finalMonth = originDate.format('MM월 ');
+  const finalDay = originDate.format('DD일');
 
-  const today = dayjs().format('YYYY-MM-DD');
+  const navigate = useNavigate();
 
   const goToSalaryPage = () => navigate(`/salary-detail/3`);
 
-  // 오늘의 스케줄만 필터링합니다.
-  const todaySchedules = schedules.filter(
-    (schedule: ISchedule) => schedule.startDate <= today && today <= schedule.endDate
-  );
-
-  console.log(todaySchedules);
+  // const schedules = useSelector((state: RootState) => state.schedules.schedules);
+  // 오늘의 스케줄 필터링
+  // const todaySchedules = schedules.filter(
+  //   (schedule: ISchedule) => schedule.startDate <= today && today <= schedule.endDate
+  // );
 
   return (
     <>
-      <Heading title="대시보드" />
       <ProfileCard />
       <CalendarCard />
       <NoticeCard
+        date={finalMonth}
         day={finalDay}
         button={true}
-        label={
-          <h5>
-            <ListOutlinedIcon />
-            급여명세서 조회
-          </h5>
-        }
+        label={<h5>급여명세서 조회</h5>}
         onClick={goToSalaryPage}
       />
+      <SalaryCard />
     </>
   );
 }

--- a/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/pages/Dashboard/DashboardPage.tsx
@@ -1,24 +1,11 @@
 import ProfileCard from './ProfileCard';
 import CalendarCard from './CalendarCard';
-import NoticeCard from '../salaryList/NoticeCard';
-import dayjs from 'dayjs';
-import { useNavigate } from 'react-router-dom';
 import SalaryCard from './SalaryCard';
 // import { useSelector } from 'react-redux';
 // import { RootState } from '../../store/store';
 // import { ISchedule } from '../../slices/scheduleSlice';
 
 function Dashboard() {
-  const currentDate = new Date();
-  const DueDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 25);
-  const originDate = dayjs(DueDate);
-  const finalMonth = originDate.format('MM월 ');
-  const finalDay = originDate.format('DD일');
-
-  const navigate = useNavigate();
-
-  const goToSalaryPage = () => navigate(`/salary-detail/3`);
-
   // const schedules = useSelector((state: RootState) => state.schedules.schedules);
   // 오늘의 스케줄 필터링
   // const todaySchedules = schedules.filter(
@@ -29,13 +16,6 @@ function Dashboard() {
     <>
       <ProfileCard />
       <CalendarCard />
-      <NoticeCard
-        date={finalMonth}
-        day={finalDay}
-        button={true}
-        label={<h5>급여명세서 조회</h5>}
-        onClick={goToSalaryPage}
-      />
       <SalaryCard />
     </>
   );

--- a/src/pages/Dashboard/ProfileCard.tsx
+++ b/src/pages/Dashboard/ProfileCard.tsx
@@ -43,6 +43,7 @@ export default function ProfileCard() {
 }
 
 const ProfileCardWrapper = styled(CardBox)`
+  border: 1px solid var(--border-sec);
   height: 19.5rem;
   padding: 0;
   overflow: hidden;

--- a/src/pages/Dashboard/SalaryCard.tsx
+++ b/src/pages/Dashboard/SalaryCard.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+import NoticeCard from '../salaryList/NoticeCard';
+import dayjs from 'dayjs';
+import styled from 'styled-components';
+
+export default function SalaryCard() {
+  const currentDate = new Date();
+  const DueDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 25);
+  const originDate = dayjs(DueDate);
+  const finalMonth = originDate.format('MM월 ');
+  const finalDay = originDate.format('DD일');
+
+  const navigate = useNavigate();
+
+  const goToSalaryPage = () => navigate(`/salary-detail/3`);
+  return (
+    <SalaryCardWrapper
+      date={finalMonth}
+      day={finalDay}
+      button={true}
+      label={<h5>급여명세서 조회</h5>}
+      onClick={goToSalaryPage}
+    />
+  );
+}
+
+export const SalaryCardWrapper = styled(NoticeCard)`
+  display: flex;
+  border: 1px solid var(--border-sec);
+  height: 19.5rem;
+  padding: 0;
+  overflow: hidden;
+  position: relative;
+  margin: 1rem 0;
+  color: red;
+`;

--- a/src/pages/Dashboard/SalaryCard.tsx
+++ b/src/pages/Dashboard/SalaryCard.tsx
@@ -25,6 +25,7 @@ export default function SalaryCard() {
 }
 
 export const SalaryCardWrapper = styled(NoticeCard)`
+  /* 하단 스타일이 적용이 되고 있지 않습니다. */
   display: flex;
   border: 1px solid var(--border-sec);
   height: 19.5rem;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

대시보드 새 디자인으로 UI 수정

## 📋 작업 내용

1. 카드 컴포넌트 디자인 통일
    - 급여명세서 카드의 경우, 다른 컴포넌트와 디자인을 맞추려고 했으나 적용이 안됨

2. 대시보드 타이틀 제거

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="326" alt="image" src="https://github.com/user-attachments/assets/3c4a7d54-636f-445b-9d2e-b19f1f2ed632">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- **Style**: Updated the styling of various components including `CardBox`, `CalendarCardWrapper`, and `ProfileCardWrapper` for improved user interface aesthetics.
- **Refactor**: Streamlined the `Dashboard` component by removing unused code and refactoring salary details related logic.
- **New Feature**: Introduced a new `SalaryCard` component that provides detailed salary information and navigation to a salary detail page, enhancing the user's ability to manage and understand their salary data.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->