### PR TITLE
[Feature] 급여명세서 내 정정버튼 동작 수정

### DIFF
--- a/src/pages/salaryDetail/DetailMonthModal.tsx
+++ b/src/pages/salaryDetail/DetailMonthModal.tsx
@@ -1,0 +1,42 @@
+import BasicDialog from "../../components/modal/BasicModal"
+import Btn from "../../components/button/Button"
+import { CloseButton } from "../../components/modal/CloseButton"
+import { useBasicModal } from "../../components/modal/useBasicModal"
+import Heading from "../../components/Heading/Heading"
+import FormWrap from "../salaryAdjustment/FormWrap"
+import * as styled from '../salaryAdjustment/SalaryAdjustment.style';
+import dayjs from "dayjs";
+
+export default function SelectedModal({month}:{month:string}){
+  const { open, handleOpen, handleClose } = useBasicModal();
+
+  const today = dayjs();
+  const payday = dayjs().month(parseInt(month, 10) - 1);
+  const isBeforeCurrentMonth = payday.isBefore(today, 'month');
+
+  if(isBeforeCurrentMonth){
+    return null
+  }
+  
+  return(
+    <BasicDialog
+      modalOpenButton={
+        <Btn label="정정신청" btnsize="sm" onClick={handleOpen} sx={{ fontSize: '1.3rem' }} />
+        }
+      modalCloseButton={<CloseButton handleClose={handleClose} />}
+      open={open}
+      >
+      <Heading title="급여 정정신청" />
+      <styled.ModalTitle>{month}월 급여 정정</styled.ModalTitle>
+      <FormWrap />
+      <Btn
+        label="취소"
+        btnsize="sm"
+        onClick={handleClose}
+        sx={{ fontSize: '1.5rem', mr: '1rem' }}
+        btntype="outlined"
+      />
+      <Btn label="확인" btnsize="md" onClick={handleClose} sx={{ fontSize: '1.5rem' }} />
+  </BasicDialog>
+  )
+}

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -1,5 +1,4 @@
 import { useNavigate, useParams } from "react-router-dom";
-import Btn from "../../components/button/Button";
 import IconBtn from "../../components/iconButton/IconButton";
 import * as Styled from './SalaryDetail.style';
 import jsPDF from "jspdf";
@@ -10,6 +9,7 @@ import useSalaryDetails from "../salaryList/useSalaryDetails";
 import MoveMonth from "./MoveMonth";
 import SalaryCard from "./SalaryCard";
 import ListWrapper from "./ListWrapper";
+import SelectedModal from "./DetailMonthModal";
 
 export default function SalaryDetailPage() {
   const navigate = useNavigate();
@@ -35,13 +35,10 @@ export default function SalaryDetailPage() {
   }
 
   const employeeProfile = employees[userId]?.profile || {};
+  
   const handleCloseButton = () => {
     navigate('/payments')
   };
-
-  const handleApply = () => {
-    navigate('/salary-adjustment')
-  }
 
   const handleDownload = () => {
     if (detailRef.current) {
@@ -65,19 +62,23 @@ export default function SalaryDetailPage() {
                 <h2>급여명세서</h2>
               </Styled.LSection>
               <Styled.RSection>
-              <Btn size="lg" label='정정신청' onClick={handleApply} />
+              <SelectedModal month={salaryData.payday.slice(5, 7)}/>
                 <IconBtn icontype="download" onClick={handleDownload} />
               </Styled.RSection>
             </Styled.Header>
             <Styled.Listline />
             <div key={salaryData.id} ref={detailRef}>
-              <MoveMonth id={salaryData.id} date={salaryData.payday} salaryData={salaryDetails[userId]} />
-                <SalaryCard
-                  id={salaryData.id}
-                  name={employeeProfile.name || '이름 없음'}
-                  realpay={salaryData.realpay}
-                  payday={salaryData.payday}
-                />
+              <MoveMonth 
+                id={salaryData.id} 
+                date={salaryData.payday} 
+                salaryData={salaryDetails[userId]} 
+              />
+              <SalaryCard
+                id={salaryData.id}
+                name={employeeProfile.name || '이름 없음'}
+                realpay={salaryData.realpay}
+                payday={salaryData.payday}
+              />
                 <Styled.Info>
                   <Styled.Listline />
                   <ListWrapper details={salaryData.details}/>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여명세서 내 정정버튼 동작 수정

## 📋 작업 내용

- 정정신청 버튼 클릭 시 정정페이지로 이동 -> 정정 신청 버튼 클릭 시
  급여명세서에 해당하는 달의 정정신청 모달 페이지가 뜨도록 수정
- 정정기간이 지난 급여명세서는 정정신청 버튼이 보이지 않도록 수정

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/70b7ba03-8015-4940-b5d9-ba5e37b5ea38)

기간이 지난 달은 정정신청 버튼 노출 x
![image](https://github.com/user-attachments/assets/c4fbdbf8-237d-4fde-9b8f-d4ee6613e888)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a `SelectedModal` component to the Salary Detail Page. This feature allows users to adjust salaries based on the selected month. The modal is activated by clicking a button and provides options to either confirm or cancel the adjustment.
- Refactor: Removed unused `Btn` component from `SalaryDetailPage` and improved code structure for better readability and maintainability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->