### PR TITLE
[Feature] 급여 정정 공지 카드, 명세서 기능 수정

### DIFF
--- a/src/pages/Dashboard/SalaryCard.tsx
+++ b/src/pages/Dashboard/SalaryCard.tsx
@@ -1,13 +1,21 @@
 import NoticeCard from '../salaryList/NoticeCard';
 import styled from 'styled-components';
+import useSalaryDetails from '../salaryList/useSalaryDetails';
 
 export default function SalaryCard() {
-  const userId = 'sajo1234567'
+  const userId = 'sajo1234567';
+  const { data, error, isLoading } = useSalaryDetails();
+
+  if (isLoading) { return <div>Loading...</div>; }
+  if (error) { return <div>Error: {error.message}</div>; }
+
+  const salary = data?.salaryDetails[userId] || [];
+  const sortedSalaryList = [...salary].sort((a, b) => b.id - a.id);
 
   return (
     <SalaryCardWrapper>
     <NoticeCard
-      userId={userId}
+      salaryList={sortedSalaryList}
       button={true}
       label={<h5>급여명세서 조회</h5>}
     />

--- a/src/pages/Dashboard/SalaryCard.tsx
+++ b/src/pages/Dashboard/SalaryCard.tsx
@@ -1,37 +1,27 @@
-import { useNavigate } from 'react-router-dom';
 import NoticeCard from '../salaryList/NoticeCard';
-import dayjs from 'dayjs';
 import styled from 'styled-components';
 
 export default function SalaryCard() {
-  const currentDate = new Date();
-  const DueDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 25);
-  const originDate = dayjs(DueDate);
-  const finalMonth = originDate.format('MM월 ');
-  const finalDay = originDate.format('DD일');
+  const userId = 'sajo1234567'
 
-  const navigate = useNavigate();
-
-  const goToSalaryPage = () => navigate(`/salary-detail/3`);
   return (
-    <SalaryCardWrapper
-      date={finalMonth}
-      day={finalDay}
+    <SalaryCardWrapper>
+    <NoticeCard
+      userId={userId}
       button={true}
       label={<h5>급여명세서 조회</h5>}
-      onClick={goToSalaryPage}
     />
+    </SalaryCardWrapper>
   );
 }
 
-export const SalaryCardWrapper = styled(NoticeCard)`
-  /* 하단 스타일이 적용이 되고 있지 않습니다. */
-  display: flex;
-  border: 1px solid var(--border-sec);
+export const SalaryCardWrapper = styled.div`
+& > div{
   height: 19.5rem;
   padding: 0;
   overflow: hidden;
   position: relative;
   margin: 1rem 0;
   color: red;
+}
 `;

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -37,7 +37,7 @@ export default function SalaryDetailPage() {
   const employeeProfile = employees[userId]?.profile || {};
   
   const handleCloseButton = () => {
-    navigate('/payments')
+    navigate(-1)
   };
 
   const handleDownload = () => {

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -3,7 +3,7 @@ import IconBtn from "../../components/iconButton/IconButton";
 import * as Styled from './SalaryDetail.style';
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
-import React, { useRef } from "react";
+import { useRef } from "react";
 import {SalaryDataItem} from '../salaryList/api/fetchSalaryInfo';
 import useSalaryDetails from "../salaryList/useSalaryDetails";
 import MoveMonth from "./MoveMonth";

--- a/src/pages/salaryList/NoticeCard.style.ts
+++ b/src/pages/salaryList/NoticeCard.style.ts
@@ -6,7 +6,7 @@ export const SalaryCardBox = styled.div`
   padding: 1.2rem 4rem 2rem 4rem;
   margin: 1rem;
   border-radius:2rem;
-  box-shadow: 0px 1px 0px 0.2px var(--border-pri);
+  border: 1px solid var(--border-sec);
   margin: 2rem auto;
   box-sizing:border-box;
 

--- a/src/pages/salaryList/NoticeCard.tsx
+++ b/src/pages/salaryList/NoticeCard.tsx
@@ -1,28 +1,58 @@
 import * as Styled from './NoticeCard.style';
 import Btn from '../../components/button/Button';
+import useSalaryDetails from './useSalaryDetails';
+import { useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
 
 type noticeData = {
-  date: string;
-  day: string;
+  userId:string;
   button?: boolean;
   label?: React.ReactNode;
-  onClick?: () => void;
 };
 
-export default function NoticeCard({ date, day, button = false, label, onClick }: noticeData) {
+
+export default function NoticeCard({ userId, button = false, label}: noticeData) {
+  const navigate = useNavigate()
+  const {data} = useSalaryDetails()
+
+  const salaryList = data?.salaryDetails[userId] || []
+  salaryList.sort((a,b) => b.id-a.id) 
+
+  const handleApplicationBtn = (id:number) => {
+    if(salaryList.find((item) => item.id === id)){
+      navigate(`/salary-detail/${id}`)
+    }else{
+          console.error('급여 명세서가 없습니다.')
+    }
+  }
+
+  if (salaryList.length === 0) {
+    return (
+      <Styled.SalaryCardBox>
+        <h2>급여명세서</h2>
+        <p>급여 명세서가 없습니다.</p>
+      </Styled.SalaryCardBox>
+    );
+  }
+
+  const firstPayData = salaryList[0]
+  const originDate = dayjs(firstPayData.payday,'YYYY.MM.DD')
+  const finalDate = originDate.format('MM월 ')
+  const finalDay = originDate.subtract(2,'day').format('DD일')
+  
   return (
     <Styled.SalaryCardBox>
       <h2>
-        <Styled.Orangetxt>{date}</Styled.Orangetxt>급여명세서
+        <Styled.Orangetxt>{finalDate}</Styled.Orangetxt>급여명세서
       </h2>
       <h6 className='imoge'>✉️</h6>
       <h3>
         <p>정정 신청 기간입니다.</p> 
         <p>
-          <Styled.Orangetxt>{day}</Styled.Orangetxt>까지 신청해주세요.
+          <Styled.Orangetxt>{finalDay}</Styled.Orangetxt>까지 신청해주세요.
         </p>
       </h3>
-      {button && <Btn btnsize="md" size="lg" label={label || <></>} onClick={onClick} />}
+      {button && <Btn btnsize="md" size="lg" label={label || <></>} onClick={()=>handleApplicationBtn(firstPayData.id)} />}
     </Styled.SalaryCardBox>
   );
 }

--- a/src/pages/salaryList/NoticeCard.tsx
+++ b/src/pages/salaryList/NoticeCard.tsx
@@ -1,22 +1,18 @@
 import * as Styled from './NoticeCard.style';
 import Btn from '../../components/button/Button';
-import useSalaryDetails from './useSalaryDetails';
+import { SalaryDataItem } from './api/fetchSalaryInfo';
 import { useNavigate } from "react-router-dom";
 import dayjs from "dayjs";
 
 type noticeData = {
-  userId:string;
+  salaryList? : Array<SalaryDataItem> 
   button?: boolean;
   label?: React.ReactNode;
 };
 
 
-export default function NoticeCard({ userId, button = false, label}: noticeData) {
-  const navigate = useNavigate()
-  const {data} = useSalaryDetails()
-
-  const salaryList = data?.salaryDetails[userId] || []
-  salaryList.sort((a,b) => b.id-a.id) 
+export default function NoticeCard({ salaryList=[], button = false, label}: noticeData) {
+  const navigate = useNavigate() 
 
   const handleApplicationBtn = (id:number) => {
     if(salaryList.find((item) => item.id === id)){

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -1,6 +1,5 @@
 import SelectBox from "../../components/selectBox/SelectBox";
 import Btn from "../../components/button/Button";
-import dayjs from "dayjs";
 import * as Styled from './SalaryList.style';
 import { useNavigate } from "react-router-dom";
 import NoticeCard from "./NoticeCard";
@@ -25,11 +24,6 @@ export default function SalaryListPage(){
   const salaryList = data?.salaryDetails[userId] || [] 
   salaryList.sort((a,b) => b.id-a.id)
 
-  const firstPayData = salaryList[0]
-  const originDate = dayjs(firstPayData.payday,'YYYY.MM.DD')
-  const finalDate = originDate.format('MM월 ')
-  const finalDay = originDate.subtract(2,'day').format('DD일')
-
   const handleApplicationBtn = (id:number) => {
     if(salaryList.find((item) => item.id === id)){
       navigate(`/salary-detail/${id}`)
@@ -41,7 +35,7 @@ export default function SalaryListPage(){
   return(
     <Styled.Salary>
       <Heading title="급여정산"/>
-      <NoticeCard date={finalDate} day={finalDay}/>
+      <NoticeCard userId={userId}/>
         <Styled.YearSelect>
         <SelectBox 
           labelId="SalaryYear" 

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -22,10 +22,10 @@ export default function SalaryListPage(){
   if (error) {return <div>Error: {error.message}</div>}
 
   const salaryList = data?.salaryDetails[userId] || [] 
-  salaryList.sort((a,b) => b.id-a.id)
+  const sortedSalaryList = [...salaryList].sort((a,b) => b.id-a.id)
 
   const handleApplicationBtn = (id:number) => {
-    if(salaryList.find((item) => item.id === id)){
+    if(sortedSalaryList.find((item) => item.id === id)){
       navigate(`/salary-detail/${id}`)
     }else{
           console.error('급여 명세서가 없습니다.')
@@ -35,7 +35,7 @@ export default function SalaryListPage(){
   return(
     <Styled.Salary>
       <Heading title="급여정산"/>
-      <NoticeCard userId={userId}/>
+      <NoticeCard salaryList={sortedSalaryList}/>
         <Styled.YearSelect>
         <SelectBox 
           labelId="SalaryYear" 
@@ -44,7 +44,7 @@ export default function SalaryListPage(){
           menuItems={years}
         />
       </Styled.YearSelect>
-        {salaryList.map((el)=>
+        {sortedSalaryList.map((el)=>
           (<Styled.ListCardBox key={el.id} $state={el.state} 
             onClick={()=>{handleApplicationBtn(el.id)}}>
             <Styled.List $state={el.state}>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여 정정 공지 카드, 명세서 기능 수정

## 📋 작업 내용

1 . 급여 정정 가능기간을 보여주기 위해 받았던 날짜 관련 props 다 삭제
     - 최근에 올라온 급여명세서의 월, 일을 보여주면 되고 사용하는 곳이 두 곳
        뿐이라 컴포넌트 내에서 데이터에 들어있는 최근 급여명세서와 관련된  날짜를 계산하고 뿌려주는 식으로 변경
     - 급여 관련 데이터를 props로 받도록 수정

2.  메인에서 사용될 공지 카드 스타일을 변경할 수 있도록 하기 위해 div를
  만들어 공지 카드를 감싼 후 styled 주는 곳에서 내부 div(카드 컴포넌트)로 접근

3. 급여명세서에서 닫기 버튼을 누르면 /payments로 가도록 navigate 처리를
해뒀더니 메인에서 급여명세서 조회를 누르고 닫기를 눌렀을 때 급여정산
페이지로 순간이동하는 이슈 발생 -> navigate(-1)로 수정하여 닫기 버튼
클릭 시  명세서 조회 전의 페이지로 돌아가도록 함


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Restructured `SalaryCard` and `NoticeCard` components for improved data handling and user navigation.
- Style: Updated the styling of `NoticeCard` for better UI consistency.
- Bug Fix: Fixed navigation issues in `SalaryDetailPage`, now correctly navigates back to the previous page.
- New Feature: Enhanced salary details display in `SalaryListPage` and `SalaryDetailPage`.
- Chore: Optimized sorting of salary data and button click handlers for better performance.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->