### PR TITLE
feat: 글로벌 폰트 사이즈 추가

### DIFF
--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -31,7 +31,13 @@ export default function GlobalStyle() {
           '--border-pri': '#9a9a9a',
           '--border-sec': '#eeeeee',
 
-          '--page-gray' : '#F0F3F8',
+          '--page-gray': '#F0F3F8',
+
+          /* font size system */
+          '--font-size-primary': '1.5rem',
+          '--font-size-small': '1.2rem',
+          '--font-size-large': '1.8rem',
+          '--font-size-xlarge': '2.2rem',
         },
         '*': {
           fontFamily: 'var(--font-family-primary)',
@@ -60,12 +66,12 @@ export default function GlobalStyle() {
           fontWeight: 'var(--font-weight-bold)',
         },
         h2: {
-          fontSize: '2.2rem',
+          fontSize: 'var(--font-size-xlarge)',
           lineHeight: '3.3rem',
           fontWeight: 'var(--font-weight-semibold)',
         },
         h3: {
-          fontSize: '1.8rem',
+          fontSize: 'var(--font-size-large)',
           lineHeight: '2.7rem',
           fontWeight: 'var(--font-weight-medium)',
         },
@@ -75,12 +81,12 @@ export default function GlobalStyle() {
           fontWeight: 'var(--font-weight-medium)',
         },
         h5: {
-          fontSize: '1.4rem',
+          fontSize: 'var(--font-size-primary)',
           lineHeight: '2.1rem',
           fontWeight: 'var(--font-weight-medium)',
         },
         h6: {
-          fontSize: '1.2rem',
+          fontSize: 'var(--font-size-small)',
           lineHeight: '1.8rem',
           fontWeight: 'var(--font-weight-medium)',
         },


### PR DESCRIPTION
- h5 태그에 글로벌 폰트 사이즈 변경 1.5rem으로
- Add global font size
- '--font-size-primary': '1.5rem',
- '--font-size-small': '1.2rem',
- '--font-size-large': '1.8rem',
- '--font-size-xlarge': '2.2rem'


## 주요 변경 사항

글로벌 스타일에 폰트 사이즈 4가지가 추가됨.

```
      '--font-size-primary': '1.5rem',
      '--font-size-small': '1.2rem',
      '--font-size-large': '1.8rem',
      '--font-size-xlarge': '2.2rem',
```
##  h2, h3, h6 글로벌 스타일 변경
- h5의 폰트 사이즈가 1.5rem 15px로 변경됨.
- 나머지는 폰트 사이즈는 유지하되 폰트 variable이 적용됨.
```
        h2: {
          fontSize: 'var(--font-size-xlarge)',
          lineHeight: '3.3rem',
          fontWeight: 'var(--font-weight-semibold)',
        },
        h3: {
          fontSize: 'var(--font-size-large)',
          lineHeight: '2.7rem',
          fontWeight: 'var(--font-weight-medium)',
        },
        h5: {
          fontSize: 'var(--font-size-primary)',
          lineHeight: '2.1rem',
          fontWeight: 'var(--font-weight-medium)',
        },
        h6: {
          fontSize: 'var(--font-size-small)',
          lineHeight: '1.8rem',
          fontWeight: 'var(--font-weight-medium)',
        },
```
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Introduced global font size variables for primary, small, large, and extra-large sizes to ensure consistency across the application.
- Refactor: Updated font sizes for h2, h3, h5, and h6 elements using the newly defined global font size variables for improved readability and visual hierarchy.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->