### PR TITLE
Feature: 급여목록 필터링 기능

### DIFF
--- a/src/pages/salaryDetail/DetailMonthModal.tsx
+++ b/src/pages/salaryDetail/DetailMonthModal.tsx
@@ -2,9 +2,9 @@ import BasicDialog from "../../components/modal/BasicModal"
 import Btn from "../../components/button/Button"
 import { CloseButton } from "../../components/modal/CloseButton"
 import { useBasicModal } from "../../components/modal/useBasicModal"
+import * as styled from '../salaryAdjustment/SalaryAdjustment.style';
 import Heading from "../../components/Heading/Heading"
 import FormWrap from "../salaryAdjustment/FormWrap"
-import * as styled from '../salaryAdjustment/SalaryAdjustment.style';
 import dayjs from "dayjs";
 
 export default function SelectedModal({month}:{month:string}){
@@ -26,17 +26,11 @@ export default function SelectedModal({month}:{month:string}){
       modalCloseButton={<CloseButton handleClose={handleClose} />}
       open={open}
       >
+      <styled.modalWrapper>
       <Heading title="급여 정정신청" />
-      <styled.ModalTitle>{month}월 급여 정정</styled.ModalTitle>
-      <FormWrap />
-      <Btn
-        label="취소"
-        btnsize="sm"
-        onClick={handleClose}
-        sx={{ fontSize: '1.5rem', mr: '1rem' }}
-        btntype="outlined"
-      />
-      <Btn label="확인" btnsize="md" onClick={handleClose} sx={{ fontSize: '1.5rem' }} />
+      <h2 className="modal-title">{month}월 급여 정정</h2>
+      <FormWrap handleClose={() => handleClose()} />
+      </styled.modalWrapper>
   </BasicDialog>
   )
 }

--- a/src/pages/salaryDetail/MoveMonth.style.ts
+++ b/src/pages/salaryDetail/MoveMonth.style.ts
@@ -11,7 +11,7 @@ export const Movemonth = styled.div`
 
   .up-date{
     font-weight:var(--font-weight-bold);
-    font-size:1.3rem;
+    font-size:var(--font-size-primary);
     margin:0 5px;
 
     .css-i4bv87-MuiSvgIcon-root{

--- a/src/pages/salaryDetail/SalaryCard.style.ts
+++ b/src/pages/salaryDetail/SalaryCard.style.ts
@@ -1,34 +1,40 @@
-import styled from "styled-components"
+import styled from 'styled-components';
 
 export const Container = styled.div`
-  text-align:center;
-  font-size:1.6rem;
+  text-align: center;
+  font-size: 1.6rem;
 
   .bold {
-    font-weight:var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
   }
   & > div {
     background: var(--color-pri-white);
     color: var(--color-white);
-    padding-bottom:5rem;
+    padding-bottom: 5rem;
   }
 `;
 
 export const ItemWrapper = styled.div`
-  display:flex;
+  display: flex;
   justify-content: space-between;
-  font-weight:var(--font-weight-bold);
+  font-weight: var(--font-weight-bold);
 
-  .pay{
-    padding-top:1rem;
-    font-size:1.2rem;
+  .pay {
+    box-sizing: border-box;
+    padding: 1rem 0rem;
+    font-size: var(--font-size-small);
   }
   .pay > h5,
-  .pay > h3{
-  font-weight:var(--font-weight-bold);
+  .pay > h3 {
+    font-weight: var(--font-weight-bold);
+  }
+
+  .info {
+    padding-top: 1.3rem;
+    font-size: var(--font-size-small);
   }
 `;
 
 export const LgFont = styled.span`
-  font-size:25px;
-`
+  font-size: var(--font-size-xlarge);
+`;

--- a/src/pages/salaryDetail/SalaryCard.tsx
+++ b/src/pages/salaryDetail/SalaryCard.tsx
@@ -1,28 +1,43 @@
 import * as Styled from './SalaryCard.style';
-import CardBox from "../../components/cardBox/CardBox";
+import CardBox from '../../components/cardBox/CardBox';
 
 type salaryData = {
   id: number;
   name: string;
   realpay: string;
   payday: string;
-}
+  level: string;
+  work: string;
+};
 
-export default function SalaryCard({id, name, realpay, payday}:salaryData){
-  return(
-  <Styled.Container>
-  <CardBox key={id}>
-    <span className="bold">{name}</span> 님의 노고에 감사드립니다.
-      <hr />
-      <Styled.ItemWrapper>
-        <div className="pay"><h5>실수령액</h5></div>
-          <div className="pay"><h3><Styled.LgFont>{realpay}</Styled.LgFont> 원</h3></div>
-      </Styled.ItemWrapper><hr/>
-      <Styled.ItemWrapper>
-        <div className="pay">급여지급일</div>
-          <div className="pay">{payday}</div>
-      </Styled.ItemWrapper>
-  </CardBox>
-  </Styled.Container>
-  )
+export default function SalaryCard({ id, name, realpay, payday, level, work }: salaryData) {
+  return (
+    <Styled.Container>
+      <CardBox key={id}>
+        <span className="bold">{name}</span> 님의 노고에 감사드립니다.
+        <Styled.ItemWrapper>
+          <div className="pay">
+            <h5>실수령액</h5>
+          </div>
+          <div className="pay">
+            <h3>
+              <Styled.LgFont>{realpay}</Styled.LgFont> 원
+            </h3>
+          </div>
+        </Styled.ItemWrapper>
+        <Styled.ItemWrapper>
+          <div className="info">급여지급일</div>
+          <div className="info">{payday}</div>
+        </Styled.ItemWrapper>
+        <Styled.ItemWrapper>
+          <div className="info">직급</div>
+          <div className="info">{level}</div>
+        </Styled.ItemWrapper>
+        <Styled.ItemWrapper>
+          <div className="info">재직기간</div>
+          <div className="info">{work}</div>
+        </Styled.ItemWrapper>
+      </CardBox>
+    </Styled.Container>
+  );
 }

--- a/src/pages/salaryDetail/SalaryDetail.style.ts
+++ b/src/pages/salaryDetail/SalaryDetail.style.ts
@@ -1,59 +1,62 @@
-import styled from "styled-components"
+import styled from 'styled-components';
 
 export const Header = styled.div`
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  box-sizing:border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
 
-  .css-i4bv87-MuiSvgIcon-root{
-    width:3rem;
-    height:3.5rem;
+  .css-i4bv87-MuiSvgIcon-root {
+    width: 3rem;
+    height: 3.5rem;
   }
 `;
 
 export const Listline = styled.div`
-  background-color:var(--border-pri);
-  height:0.05rem;
+  background-color: var(--border-pri);
+  height: 0.05rem;
 `;
 
 export const Thinline = styled.div`
-  background-color:var(--border-sec);
-  height:0.05rem;
+  background-color: var(--border-sec);
+  height: 0.05rem;
 `;
 
 export const LSection = styled.div`
-  display: flex;  
-  align-items:center;
-  gap: 1rem; 
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 `;
 
 export const RSection = styled.div`
   display: flex;
-  align-items:center;
-  gap: 1rem; 
+  align-items: center;
+  gap: 1rem;
 `;
 
-export const ListWrapper = styled.div<{ type?:string, content?:string}>`
-  display:flex;
+export const ListWrapper = styled.div<{ type?: string; content?: string }>`
+  display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding:2rem 1rem;
-  box-sizing:border-box;
-  
-  div{
-    font-size: ${props => props.type === 'main' ? '1.4rem' : '1.2rem'};
-    font-weight: ${props => props.type === 'main' ? 'bold' : 'normal'};
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+
+  div {
+    font-size: ${(props) => (props.type === 'main' ? '1.4rem' : 'var(--font-size-small)')};
+    font-weight: ${(props) => (props.type === 'main' ? 'bold' : 'normal')};
   }
-  .price{
-    color: ${props => 
-      props.content === 'pension' ? '#039C00' :
-      props.content === 'deduction' ? '#CC4846' :
-      props.content === 'pay' ? 'var(--color-pri)' : 
-      'var(--color-black)'}
+  .price {
+    color: ${(props) =>
+      props.content === 'pension'
+        ? '#039C00'
+        : props.content === 'deduction'
+          ? '#CC4846'
+          : props.content === 'pay'
+            ? 'var(--color-pri)'
+            : 'var(--color-black)'};
   }
 `;
 
 export const Info = styled.div`
-  margin-top:2.3rem;
+  margin-top: 2.3rem;
 `;

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -37,7 +37,7 @@ export default function SalaryDetailPage() {
   const employeeProfile = employees[userId]?.profile || {};
   
   const handleCloseButton = () => {
-    navigate(-1)
+    navigate('/payments')
   };
 
   const handleDownload = () => {

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -1,30 +1,32 @@
-import { useNavigate, useParams } from "react-router-dom";
-import IconBtn from "../../components/iconButton/IconButton";
+import { useNavigate, useParams } from 'react-router-dom';
+import IconBtn from '../../components/iconButton/IconButton';
 import * as Styled from './SalaryDetail.style';
-import jsPDF from "jspdf";
-import html2canvas from "html2canvas";
-import { useRef, useEffect, useState } from "react";
-import {SalaryDataItem} from '../salaryList/api/fetchSalaryInfo';
-import useSalaryDetails from "../salaryList/useSalaryDetails";
-import MoveMonth from "./MoveMonth";
-import SalaryCard from "./SalaryCard";
-import ListWrapper from "./ListWrapper";
-import SelectedModal from "./DetailMonthModal";
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+import { useRef, useEffect, useState } from 'react';
+import { SalaryDataItem } from '../salaryList/api/fetchSalaryInfo';
+import useSalaryDetails from '../salaryList/useSalaryDetails';
+import MoveMonth from './MoveMonth';
+import SalaryCard from './SalaryCard';
+import ListWrapper from './ListWrapper';
+import SelectedModal from './DetailMonthModal';
 
 export default function SalaryDetailPage() {
   const navigate = useNavigate();
   const { id } = useParams<{ id?: string }>();
-  const userId = "sajo1234567";
+  const userId = 'sajo1234567';
 
-  const { data, error, isLoading } = useSalaryDetails()
-  const detailRef = useRef<HTMLDivElement>(null)
+  const { data, error, isLoading } = useSalaryDetails();
+  const detailRef = useRef<HTMLDivElement>(null);
 
   const [salaryData, setSalaryData] = useState<SalaryDataItem | null>(null);
 
   useEffect(() => {
     if (data && id) {
       const salaryDetails = data.salaryDetails;
-      const fetchedSalaryData = salaryDetails[userId]?.find((item: SalaryDataItem) => item.id === parseInt(id));
+      const fetchedSalaryData = salaryDetails[userId]?.find(
+        (item: SalaryDataItem) => item.id === parseInt(id)
+      );
 
       if (!fetchedSalaryData) {
         navigate('/payments');
@@ -50,56 +52,62 @@ export default function SalaryDetailPage() {
 
   const employees = data.employees;
   const employeeProfile = employees[userId]?.profile || {};
-  
+
   const handleCloseButton = () => {
-    navigate('/payments')
+    navigate('/payments');
   };
 
   const handleDownload = () => {
     if (detailRef.current) {
-        html2canvas(detailRef.current).then(canvas => {
-          const imgData = canvas.toDataURL('image/png')
-          const pdf = new jsPDF()
-          const imgProps = pdf.getImageProperties(imgData)
-          const pdfWidth = pdf.internal.pageSize.getWidth()
-          const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width
-          pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight)
-          pdf.save(`${employeeProfile.name || '급여명세서'}_${salaryData.payday.slice(5, 7)}월_급여명세서.pdf`)
-        }).catch(console.error)
-      }
-    };
+      html2canvas(detailRef.current)
+        .then((canvas) => {
+          const imgData = canvas.toDataURL('image/png');
+          const pdf = new jsPDF();
+          const imgProps = pdf.getImageProperties(imgData);
+          const pdfWidth = pdf.internal.pageSize.getWidth();
+          const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+          pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+          pdf.save(
+            `${employeeProfile.name || '급여명세서'}_${salaryData.payday.slice(5, 7)}월_급여명세서.pdf`
+          );
+        })
+        .catch(console.error);
+    }
+  };
 
-    return (
-        <>
-          <Styled.Header>
-            <Styled.LSection>
-              <IconBtn icontype="close" onClick={handleCloseButton} />
-                <h2>급여명세서</h2>
-              </Styled.LSection>
-              <Styled.RSection>
-              <SelectedModal month={salaryData.payday.slice(5, 7)}/>
-                <IconBtn icontype="download" onClick={handleDownload} />
-              </Styled.RSection>
-            </Styled.Header>
-            <Styled.Listline />
-            <div key={salaryData.id} ref={detailRef}>
-              <MoveMonth 
-                id={salaryData.id} 
-                date={salaryData.payday} 
-                salaryData={data.salaryDetails[userId]} 
-              />
-              <SalaryCard
-                id={salaryData.id}
-                name={employeeProfile.name || '이름 없음'}
-                realpay={salaryData.realpay}
-                payday={salaryData.payday}
-              />
-                <Styled.Info>
-                  <Styled.Listline />
-                  <ListWrapper details={salaryData.details}/>
-                  <Styled.Listline />
-                </Styled.Info>
-          </div>
-        </>
-    );
+  return (
+    <>
+      <Styled.Header>
+        <Styled.LSection>
+          <IconBtn icontype="close" onClick={handleCloseButton} />
+          <h2>급여명세서</h2>
+        </Styled.LSection>
+        <Styled.RSection>
+          <SelectedModal month={salaryData.payday.slice(5, 7)} />
+          <IconBtn icontype="download" onClick={handleDownload} />
+        </Styled.RSection>
+      </Styled.Header>
+      <Styled.Listline />
+      <div key={salaryData.id} ref={detailRef}>
+        <MoveMonth
+          id={salaryData.id}
+          date={salaryData.payday}
+          salaryData={data.salaryDetails[userId]}
+        />
+        <SalaryCard
+          id={salaryData.id}
+          name={employeeProfile.name || '이름 없음'}
+          realpay={salaryData.realpay}
+          payday={salaryData.payday}
+          level={salaryData.level}
+          work={salaryData.work}
+        />
+        <Styled.Info>
+          <Styled.Listline />
+          <ListWrapper details={salaryData.details} />
+          <Styled.Listline />
+        </Styled.Info>
+      </div>
+    </>
+  );
 }

--- a/src/pages/salaryList/NoticeCard.style.ts
+++ b/src/pages/salaryList/NoticeCard.style.ts
@@ -1,31 +1,30 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const SalaryCardBox = styled.div`
-  color:var(--color-black);
-  background-color:var(--color-white);
+  background-color: var(--color-white);
   padding: 1.2rem 4rem 2rem 4rem;
   margin: 1rem;
-  border-radius:2rem;
+  border-radius: 2rem;
   border: 1px solid var(--border-sec);
   margin: 2rem auto;
-  box-sizing:border-box;
+  box-sizing: border-box;
 
-  .imoge{
-    font-size:60px;
-    text-align:end;
+  .imoge {
+    font-size: 60px;
+    text-align: end;
   }
 
-  h2{
-    line-height:4rem;
-    font-weight:var(--font-weight-semi);
+  h2 {
+    line-height: 4rem;
+    font-weight: var(--font-weight-semi);
   }
-  h3{
-    font-weight:var(--font-weight-semi);
-    margin-bottom:15px;
+  h3 {
+    font-weight: var(--font-weight-semi);
+    margin-bottom: 15px;
   }
 `;
 
 export const Orangetxt = styled.span`
-  color:var(--color-pri);
-  font-weight:800;
+  color: var(--color-pri);
+  font-weight: 800;
 `;

--- a/src/pages/salaryList/NoticeCard.tsx
+++ b/src/pages/salaryList/NoticeCard.tsx
@@ -1,26 +1,25 @@
 import * as Styled from './NoticeCard.style';
 import Btn from '../../components/button/Button';
 import { SalaryDataItem } from './api/fetchSalaryInfo';
-import { useNavigate } from "react-router-dom";
-import dayjs from "dayjs";
+import { useNavigate } from 'react-router-dom';
+import dayjs from 'dayjs';
 
 type noticeData = {
-  salaryList? : Array<SalaryDataItem> 
+  salaryList?: Array<SalaryDataItem>;
   button?: boolean;
   label?: React.ReactNode;
 };
 
+export default function NoticeCard({ salaryList = [], button = false, label }: noticeData) {
+  const navigate = useNavigate();
 
-export default function NoticeCard({ salaryList=[], button = false, label}: noticeData) {
-  const navigate = useNavigate() 
-
-  const handleApplicationBtn = (id:number) => {
-    if(salaryList.find((item) => item.id === id)){
-      navigate(`/salary-detail/${id}`)
-    }else{
-          console.error('급여 명세서가 없습니다.')
+  const handleApplicationBtn = (id: number) => {
+    if (salaryList.find((item) => item.id === id)) {
+      navigate(`/salary-detail/${id}`);
+    } else {
+      console.error('급여 명세서가 없습니다.');
     }
-  }
+  };
 
   if (salaryList.length === 0) {
     return (
@@ -31,24 +30,31 @@ export default function NoticeCard({ salaryList=[], button = false, label}: noti
     );
   }
 
-  const firstPayData = salaryList[0]
-  const originDate = dayjs(firstPayData.payday,'YYYY.MM.DD')
-  const finalDate = originDate.format('MM월 ')
-  const finalDay = originDate.subtract(2,'day').format('DD일')
-  
+  const firstPayData = salaryList[0];
+  const originDate = dayjs(firstPayData.payday, 'YYYY.MM.DD');
+  const finalDate = originDate.format('MM월 ');
+  const finalDay = originDate.subtract(2, 'day').format('DD일');
+
   return (
     <Styled.SalaryCardBox>
       <h2>
         <Styled.Orangetxt>{finalDate}</Styled.Orangetxt>급여명세서
       </h2>
-      <h6 className='imoge'>✉️</h6>
+      <h6 className="imoge">✉️</h6>
       <h3>
-        <p>정정 신청 기간입니다.</p> 
+        <p>정정 신청 기간입니다.</p>
         <p>
           <Styled.Orangetxt>{finalDay}</Styled.Orangetxt>까지 신청해주세요.
         </p>
       </h3>
-      {button && <Btn btnsize="md" size="lg" label={label || <></>} onClick={()=>handleApplicationBtn(firstPayData.id)} />}
+      {button && (
+        <Btn
+          btnsize="md"
+          size="lg"
+          label={label || <></>}
+          onClick={() => handleApplicationBtn(firstPayData.id)}
+        />
+      )}
     </Styled.SalaryCardBox>
   );
 }

--- a/src/pages/salaryList/SalaryList.style.ts
+++ b/src/pages/salaryList/SalaryList.style.ts
@@ -5,12 +5,11 @@ export const YearSelect = styled.div`
   min-width:20%;
 
   & > div > div > div {
-    height: 40px;
+    height: 30px;
     min-height: 1.4375em;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    outline:none;
   }
   & .MuiOutlinedInput-notchedOutline {
     border: none;
@@ -57,10 +56,10 @@ export const List = styled.div<{$state:boolean}>`
   & > .title {
     font-weight: ${({$state}) => $state === true? 'var(--font-weight-bold)' : 'var(font-weight-semibold)'};
     line-height: 3.2rem;
-    font-size: 1.5rem;
+    font-size: var(--font-size-primary);
   }
   & > .date {
-    font-size: 13px;
+    font-size: var(--font-size-small);
     color: ${({$state}) => $state === true? 'var(--font-pri)' : 'var(--font-sec)'};
     text-align:left;
   }

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -24,10 +24,12 @@ export default function SalaryListPage(){
 
   const salaryList = data?.salaryDetails[userId] || [] 
   const filteredItem = salaryList.filter((item) => Number(item.payday.slice(0,4)) === Number(selectedYear))
-  const sortedSalaryList = [...filteredItem].sort((a,b) => b.id-a.id)
+  const sortedData = [...filteredItem].sort((a,b) => b.id-a.id)
+  const latestSalaryList = [...salaryList].sort((a, b) => new Date(b.payday).getTime() - new Date(a.payday).getTime());
+  const latestData = latestSalaryList.length > 0 ? [latestSalaryList[0]] : [];
 
   const handleApplicationBtn = (id:number) => {
-    if(sortedSalaryList.find((item) => item.id === id)){
+    if(sortedData.find((item) => item.id === id)){
       navigate(`/salary-detail/${id}`)
     }else{
       navigate('/payments')
@@ -37,7 +39,7 @@ export default function SalaryListPage(){
   return(
     <Styled.Salary>
       <Heading title="급여정산"/>
-      <NoticeCard salaryList={sortedSalaryList}/>
+      <NoticeCard salaryList={latestData}/>
         <Styled.YearSelect>
         <SelectBox 
           labelId="SalaryYear" 
@@ -45,10 +47,24 @@ export default function SalaryListPage(){
           label="year" 
           menuItems={years}
           value={selectedYear}
-          onChange={(e) => setSelectedYear(Number(e.target.value))}
+          onChange={(e) => setSelectedYear(Number(e.target.value))
+          }
+          sx={{'& .MuiInputLabel-root': {
+              fontSize: 'var(--font-size-primary)', 
+            },
+            '& .MuiSelect-select': {
+              fontSize: 'var(--font-size-small)', 
+            },
+            '& .MuiSelect-icon': {
+              fontSize: '2rem',
+              right: '2rem',
+              transform: 'translateY(-50%)',
+              top: '40%'
+            }
+          }}
         />
       </Styled.YearSelect>
-        {sortedSalaryList.map((el)=>
+        {sortedData.map((el)=>
           (<Styled.ListCardBox key={el.id} $state={el.state} 
             onClick={()=>{handleApplicationBtn(el.id)}}>
             <Styled.List $state={el.state}>

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -5,9 +5,9 @@ import { useNavigate } from "react-router-dom";
 import NoticeCard from "./NoticeCard";
 import useSalaryDetails from "./useSalaryDetails";
 import Heading from "../../components/Heading/Heading";
+import { useState } from "react";
 
 const years = [
-  { value: '2021', text: '2021' },
   { value: '2022', text: '2022' },
   { value: '2023', text: '2023' },
   { value: '2024', text: '2024' },
@@ -16,13 +16,15 @@ const years = [
 export default function SalaryListPage(){
   const navigate = useNavigate()
   const userId = "sajo1234567"
+  const [selectedYear, setSelectedYear] = useState<number>(2024)
   const {data, error, isLoading} = useSalaryDetails()
 
   if (isLoading) {return <div>Loading...</div>}
   if (error) {return <div>Error: {error.message}</div>}
 
   const salaryList = data?.salaryDetails[userId] || [] 
-  const sortedSalaryList = [...salaryList].sort((a,b) => b.id-a.id)
+  const filteredItem = salaryList.filter((item) => Number(item.payday.slice(0,4)) === Number(selectedYear))
+  const sortedSalaryList = [...filteredItem].sort((a,b) => b.id-a.id)
 
   const handleApplicationBtn = (id:number) => {
     if(sortedSalaryList.find((item) => item.id === id)){
@@ -42,6 +44,8 @@ export default function SalaryListPage(){
           id="year-select" 
           label="year" 
           menuItems={years}
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
         />
       </Styled.YearSelect>
         {sortedSalaryList.map((el)=>

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -30,7 +30,7 @@ export default function SalaryListPage(){
     if(sortedSalaryList.find((item) => item.id === id)){
       navigate(`/salary-detail/${id}`)
     }else{
-          console.error('급여 명세서가 없습니다.')
+      navigate('/payments')
     }
   }
 

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -1,11 +1,11 @@
-import SelectBox from "../../components/selectBox/SelectBox";
-import Btn from "../../components/button/Button";
+import SelectBox from '../../components/selectBox/SelectBox';
+import Btn from '../../components/button/Button';
 import * as Styled from './SalaryList.style';
-import { useNavigate } from "react-router-dom";
-import NoticeCard from "./NoticeCard";
-import useSalaryDetails from "./useSalaryDetails";
-import Heading from "../../components/Heading/Heading";
-import { useState } from "react";
+import { useNavigate } from 'react-router-dom';
+import NoticeCard from './NoticeCard';
+import useSalaryDetails from './useSalaryDetails';
+import Heading from '../../components/Heading/Heading';
+import { useState } from 'react';
 
 const years = [
   { value: '2022', text: '2022' },
@@ -13,72 +13,89 @@ const years = [
   { value: '2024', text: '2024' },
 ];
 
-export default function SalaryListPage(){
-  const navigate = useNavigate()
-  const userId = "sajo1234567"
-  const [selectedYear, setSelectedYear] = useState<number>(2024)
-  const {data, error, isLoading} = useSalaryDetails()
+export default function SalaryListPage() {
+  const navigate = useNavigate();
+  const userId = 'sajo1234567';
+  const [selectedYear, setSelectedYear] = useState<number>(2024);
+  const { data, error, isLoading } = useSalaryDetails();
 
-  if (isLoading) {return <div>Loading...</div>}
-  if (error) {return <div>Error: {error.message}</div>}
-
-  const salaryList = data?.salaryDetails[userId] || [] 
-  const filteredItem = salaryList.filter((item) => Number(item.payday.slice(0,4)) === Number(selectedYear))
-  const sortedData = [...filteredItem].sort((a,b) => b.id-a.id)
-  const latestSalaryList = [...salaryList].sort((a, b) => new Date(b.payday).getTime() - new Date(a.payday).getTime());
-  const latestData = latestSalaryList.length > 0 ? [latestSalaryList[0]] : [];
-
-  const handleApplicationBtn = (id:number) => {
-    if(sortedData.find((item) => item.id === id)){
-      navigate(`/salary-detail/${id}`)
-    }else{
-      navigate('/payments')
-    }
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
   }
 
-  return(
+  const salaryList = data?.salaryDetails[userId] || [];
+
+  //목록에 활용되는 데이터
+  const filteredItem = salaryList.filter((item) => +item.payday.slice(0, 4) === +selectedYear);
+  const sortedData = [...filteredItem].sort((a, b) => b.id - a.id);
+
+  //카드에 활용되는 데이터
+  const latestSalaryList = [...salaryList].sort(
+    (a, b) => new Date(b.payday).getTime() - new Date(a.payday).getTime()
+  );
+  const latestData = latestSalaryList.length > 0 ? [latestSalaryList[0]] : [];
+
+  const salaryIdSet = new Set(sortedData.map((item) => item.id));
+  const handleApplicationBtn = (id: number) => {
+    if (salaryIdSet.has(id)) {
+      navigate(`/salary-detail/${id}`);
+    } else {
+      navigate('/payments');
+    }
+  };
+
+  return (
     <Styled.Salary>
-      <Heading title="급여정산"/>
-      <NoticeCard salaryList={latestData}/>
-        <Styled.YearSelect>
-        <SelectBox 
-          labelId="SalaryYear" 
-          id="year-select" 
-          label="year" 
+      <Heading title="급여정산" />
+      <NoticeCard salaryList={latestData} />
+      <Styled.YearSelect>
+        <SelectBox
+          labelId="SalaryYear"
+          id="year-select"
+          label="year"
           menuItems={years}
           value={selectedYear}
-          onChange={(e) => setSelectedYear(Number(e.target.value))
-          }
-          sx={{'& .MuiInputLabel-root': {
-              fontSize: 'var(--font-size-primary)', 
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
+          sx={{
+            '& .MuiInputLabel-root': {
+              fontSize: 'var(--font-size-primary)',
             },
             '& .MuiSelect-select': {
-              fontSize: 'var(--font-size-small)', 
+              fontSize: 'var(--font-size-small)',
             },
             '& .MuiSelect-icon': {
               fontSize: '2rem',
               right: '2rem',
               transform: 'translateY(-50%)',
-              top: '40%'
-            }
+              top: '40%',
+            },
           }}
         />
       </Styled.YearSelect>
-        {sortedData.map((el)=>
-          (<Styled.ListCardBox key={el.id} $state={el.state} 
-            onClick={()=>{handleApplicationBtn(el.id)}}>
-            <Styled.List $state={el.state}>
+      {sortedData.map((el) => (
+        <Styled.ListCardBox
+          key={el.id}
+          $state={el.state}
+          onClick={() => {
+            handleApplicationBtn(el.id);
+          }}
+        >
+          <Styled.List $state={el.state}>
             <span className="title">{el.title}</span>
             <span className="date">{el.state === true ? '지급예정' : el.payday}</span>
-            </Styled.List>
-            <Styled.Btn>
-              {el.state === true ? 
-              <Btn round ='true' btntype='outlined' size='lg' label='신청가능'/> 
-              : 
-              <Btn round='true' disabled size='lg' label='지급완료'/> 
-              }
-            </Styled.Btn>
-        </Styled.ListCardBox>))}
+          </Styled.List>
+          <Styled.Btn>
+            {el.state === true ? (
+              <Btn round="true" btntype="outlined" size="lg" label="신청가능" />
+            ) : (
+              <Btn round="true" disabled size="lg" label="지급완료" />
+            )}
+          </Styled.Btn>
+        </Styled.ListCardBox>
+      ))}
     </Styled.Salary>
-    )
+  );
 }

--- a/src/pages/salaryList/api/fetchSalaryInfo.ts
+++ b/src/pages/salaryList/api/fetchSalaryInfo.ts
@@ -5,7 +5,7 @@ export interface SalaryDetailItem {
   label: string;
   value: string;
   type?: 'main' | 'sub';
-  content?:string;
+  content?: string;
 }
 
 export interface SalaryDataItem {
@@ -14,6 +14,8 @@ export interface SalaryDataItem {
   payday: string;
   state: boolean;
   title: string;
+  level: string;
+  work: string;
   details: SalaryDetailItem[];
 }
 
@@ -44,22 +46,21 @@ export async function fetchSalaryDetails(): Promise<{
       get(salaryDetailsRef),
     ]);
 
-    const salaryDetails = salaryDetailsSnapshot.exists() 
+    const salaryDetails = salaryDetailsSnapshot.exists()
       ? (salaryDetailsSnapshot.val() as SalaryDetails)
       : {};
 
-    const employees = employeesSnapshot.exists() 
-      ? (employeesSnapshot.val() as Employees)
-      : {};
+    const employees = employeesSnapshot.exists() ? (employeesSnapshot.val() as Employees) : {};
 
     return {
-      salaryDetails, employees
-      };
-    } catch (error) {
-      console.error('Error fetching data:', error);
-      return {
-        salaryDetails: {},
-        employees: {},
-      };
-    }
+      salaryDetails,
+      employees,
+    };
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    return {
+      salaryDetails: {},
+      employees: {},
+    };
+  }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여목록 페이지 필터링 기능 구현 및 ui 수정

## 📋 작업 내용

- 연도별 데이터 추가
- 급여 목록 페이지 연도별 필터링 조회 기능 추가
- 존재하지 않는 급여명세서 링크로 사용자가 임의로 접속하려고 하는 경우 급여명세서 목록 홈으로 이동하도록 수정
- 글로벌 스타일 폰트 사이즈 적용
- 급여명세서 내 hr 삭제
- 필터링으로 연도별 목록 조회 시 공지 카드 내 8월이 12월로 바뀌는 버그 수정

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- New Feature: Added `level` and `work` fields to the Salary Card for more detailed information.
- New Feature: Implemented year-based filtering on the Salary Detail Page and Salary List Page.
- Improvement: Enhanced UI with adjustments to text alignment, font sizes, padding, and font weights.
- Bug Fix: Resolved minor inconsistencies in variable declarations and function calls.
- Refactor: Improved data fetching and error handling in `SalaryDetailPage` and `SalaryListPage`.
- Refactor: Updated `fetchSalaryDetails` function for better readability and error management.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->