### PR TITLE
[Fix/modal] 모바일에서 모달 꽉차게 수정

### DIFF
--- a/src/components/modal/BasicModal.tsx
+++ b/src/components/modal/BasicModal.tsx
@@ -4,6 +4,8 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import { DialogProps } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
 
 interface BasicDialogProps extends Omit<DialogProps, 'children'> {
   children?: React.ReactNode;
@@ -19,10 +21,12 @@ export default function BasicDialog({
   title,
   ...props
 }: BasicDialogProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
   return (
     <div>
       {modalOpenButton}
-      <Dialog {...props}>
+      <Dialog fullScreen={fullScreen} {...props}>
         {title && <DialogTitle>{title}</DialogTitle>}
         <DialogContent>{children}</DialogContent>
         <DialogActions>{modalCloseButton}</DialogActions>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

반응형 모달로 수정

## 📋 작업 내용

mui에서 제공하는 useMediaQuery 훅을 사용하여 모바일에선 화면에 꽉차게끔 보이도록 수정.

## 📸 스크린샷 (선택 사항)

<img width="418" alt="image" src="https://github.com/user-attachments/assets/29458429-be93-4cdc-8796-bee22d9278a5">


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the user interface of our application by introducing a responsive modal design. With the integration of `useMediaQuery` and `useTheme` from Material-UI, modals will now automatically adjust to full screen on mobile devices, providing a more immersive and user-friendly experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->