### PR TITLE
Fix : 정정신청 버튼 최근 명세서에서만 보이게 수정

### DIFF
--- a/src/pages/salaryDetail/DetailMonthModal.tsx
+++ b/src/pages/salaryDetail/DetailMonthModal.tsx
@@ -1,36 +1,41 @@
-import BasicDialog from "../../components/modal/BasicModal"
-import Btn from "../../components/button/Button"
-import { CloseButton } from "../../components/modal/CloseButton"
-import { useBasicModal } from "../../components/modal/useBasicModal"
+import BasicDialog from '../../components/modal/BasicModal';
+import Btn from '../../components/button/Button';
+import { CloseButton } from '../../components/modal/CloseButton';
+import { useBasicModal } from '../../components/modal/useBasicModal';
 import * as styled from '../salaryAdjustment/SalaryAdjustment.style';
-import Heading from "../../components/Heading/Heading"
-import FormWrap from "../salaryAdjustment/FormWrap"
-import dayjs from "dayjs";
+import Heading from '../../components/Heading/Heading';
+import FormWrap from '../salaryAdjustment/FormWrap';
+import dayjs from 'dayjs';
 
-export default function SelectedModal({month}:{month:string}){
+export default function SelectedModal({ day }: { day: string }) {
   const { open, handleOpen, handleClose } = useBasicModal();
 
   const today = dayjs();
-  const payday = dayjs().month(parseInt(month, 10) - 1);
-  const isBeforeCurrentMonth = payday.isBefore(today, 'month');
+  const payday = dayjs(day, 'YYYY.MM.DD');
+  const isBeforeCurrentMonth = payday.isBefore(today, 'day');
 
-  if(isBeforeCurrentMonth){
-    return null
+  const currentMonth = today.month();
+  const paydayMonth = payday.month();
+
+  if (isBeforeCurrentMonth) {
+    return null;
   }
-  
-  return(
+
+  return (
     <BasicDialog
       modalOpenButton={
-        <Btn label="정정신청" btnsize="sm" onClick={handleOpen} sx={{ fontSize: '1.3rem' }} />
-        }
+        currentMonth >= paydayMonth ? (
+          <Btn label="정정신청" btnsize="sm" onClick={handleOpen} sx={{ fontSize: '1.3rem' }} />
+        ) : undefined
+      }
       modalCloseButton={<CloseButton handleClose={handleClose} />}
       open={open}
-      >
+    >
       <styled.modalWrapper>
-      <Heading title="급여 정정신청" />
-      <h2 className="modal-title">{month}월 급여 정정</h2>
-      <FormWrap handleClose={() => handleClose()} />
+        <Heading title="급여 정정신청" />
+        <h2 className="modal-title">{day.slice(0, 4)}월 급여 정정</h2>
+        <FormWrap handleClose={() => handleClose()} />
       </styled.modalWrapper>
-  </BasicDialog>
-  )
+    </BasicDialog>
+  );
 }

--- a/src/pages/salaryDetail/ListWrapper.tsx
+++ b/src/pages/salaryDetail/ListWrapper.tsx
@@ -1,28 +1,24 @@
 import React from 'react';
 import * as Styled from './SalaryDetail.style';
-import {SalaryDetailItem} from '../salaryList/api/fetchSalaryInfo';
+import { SalaryDetailItem } from '../salaryList/api/fetchSalaryInfo';
 
 interface ListWrapperItems {
-  details: SalaryDetailItem[]
+  details: SalaryDetailItem[];
 }
 
-export default function ListWrapper({details}:ListWrapperItems) {
-    return (
-    <>     
-    {details.map((item, index)=>
-      <React.Fragment key={index}>
-        <Styled.ListWrapper type={item.type} content={item.content}>
-          <div>{item.label}</div>
-          <div className='price'>{item.value} 원</div>
-        </Styled.ListWrapper>
-        {item.type === 'main' && index !== details.length - 1 && (
-          <Styled.Thinline />
-        )}
-        {item.type === 'sub' && index !== details.length - 1 &&
-          (<Styled.Listline/>)
-        }
+export default function ListWrapper({ details }: ListWrapperItems) {
+  return (
+    <>
+      {details.map((item, index) => (
+        <React.Fragment key={index}>
+          <Styled.ListWrapper type={item.type} content={item.content}>
+            <div>{item.label}</div>
+            <div className="price">{item.value} 원</div>
+          </Styled.ListWrapper>
+          {item.type === 'main' && index !== details.length - 1 && <Styled.Listline />}
+          {item.type === 'sub' && <Styled.Thinline />}
         </React.Fragment>
-        )}
-      </>
-    );
-  }
+      ))}
+    </>
+  );
+}

--- a/src/pages/salaryDetail/SalaryCard.style.ts
+++ b/src/pages/salaryDetail/SalaryCard.style.ts
@@ -10,7 +10,7 @@ export const Container = styled.div`
   & > div {
     background: var(--color-pri-white);
     color: var(--color-white);
-    padding-bottom: 5rem;
+    padding: 4rem 2rem;
   }
 `;
 
@@ -21,7 +21,7 @@ export const ItemWrapper = styled.div`
 
   .pay {
     box-sizing: border-box;
-    padding: 1rem 0rem;
+    margin: 2rem 0rem;
     font-size: var(--font-size-small);
   }
   .pay > h5,

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -83,7 +83,7 @@ export default function SalaryDetailPage() {
           <h2>급여명세서</h2>
         </Styled.LSection>
         <Styled.RSection>
-          <SelectedModal month={salaryData.payday.slice(5, 7)} />
+          <SelectedModal day={salaryData.payday} />
           <IconBtn icontype="download" onClick={handleDownload} />
         </Styled.RSection>
       </Styled.Header>

--- a/src/pages/salaryDetail/SalaryDetailPage.tsx
+++ b/src/pages/salaryDetail/SalaryDetailPage.tsx
@@ -103,9 +103,7 @@ export default function SalaryDetailPage() {
           work={salaryData.work}
         />
         <Styled.Info>
-          <Styled.Listline />
           <ListWrapper details={salaryData.details} />
-          <Styled.Listline />
         </Styled.Info>
       </div>
     </>

--- a/src/pages/salaryList/SalaryListPage.tsx
+++ b/src/pages/salaryList/SalaryListPage.tsx
@@ -68,7 +68,7 @@ export default function SalaryListPage() {
             },
             '& .MuiSelect-icon': {
               fontSize: '2rem',
-              right: '2rem',
+              right: '1rem',
               transform: 'translateY(-50%)',
               top: '40%',
             },


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

정정신청 버튼 최근 명세서에서만 보이게 수정, 명세서 ui 수정

## 📋 작업 내용

- 정정신청 버튼 노출 기준 수정 월 기준 비교 -> 년,월,일 기준 비교
- 급여명세서 카드 margin, padding 값 수정하여 여백 생성
- 셀렉트 박스 버튼 위치 수정 

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 기능 추가: `SelectedModal` 컴포넌트를 일 기준으로 날짜 비교 및 버튼 가시성 조정
- 기능 변경: `SalaryDetailPage`에서 `SelectedModal`로 전달되는 prop 수정
- 스타일 변경: 패딩 및 마진 조정, MuiSelect 아이콘 위치 조정
- 리팩터링: ListWrapper 함수 내부의 조건문 및 JSX 렌더링 변경
- 기능 변경: `SalaryDetailPage`에서 `SelectedModal` 호출 시 prop 변경 및 요소 제거
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->