### PR TITLE
정정내역페이지 로딩컴포넌트 적용

### DIFF
--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -4,7 +4,10 @@ import Box from '@mui/material/Box';
 
 export default function Loading() {
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+    <Box
+      className="loading"
+      sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}
+    >
       <CircularProgress />
     </Box>
   );

--- a/src/pages/salaryAdjustment/AccordionList.tsx
+++ b/src/pages/salaryAdjustment/AccordionList.tsx
@@ -5,11 +5,10 @@ import { deleteSalaryAdData, fetchSalaryAdData } from '../../slices/salaryAdSlic
 import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from '../../store/store';
 import CardBox from '../../components/cardBox/CardBox';
-
 import { useEffect } from 'react';
+import Loading from '../../components/loading/Loading';
 
 import * as styled from './SalaryAdjustment.style';
-import Btn from '../../components/button/Button';
 
 function AccordionList() {
   const dispatch = useDispatch<AppDispatch>();
@@ -20,17 +19,17 @@ function AccordionList() {
   }, [dispatch]);
 
   if (status === 'loading') {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   if (status === 'failed') {
     return <div>Error: {error}</div>;
   }
 
-  const handleEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.stopPropagation();
-    confirm('수정 하시겠습니까?');
-  };
+  // const handleEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  //   e.stopPropagation();
+  //   confirm('수정 하시겠습니까?');
+  // };
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
     const id = String(e.currentTarget.closest('.accordion')?.getAttribute('data-id'));

--- a/src/pages/salaryAdjustment/SalaryAdjustment.style.ts
+++ b/src/pages/salaryAdjustment/SalaryAdjustment.style.ts
@@ -4,6 +4,9 @@ import { styled as muiStyled } from '@mui/material/styles';
 
 export const Wrapper = styled.div`
   font-size: 1.5rem;
+  .loading {
+    height: calc(100vh - 210px);
+  }
   .btnArea {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

정정내역페이지 로딩컴포넌트 적용

## 📋 작업 내용

정정내역페이지 로딩컴포넌트 적용


## 📸 스크린샷 (선택 사항)
<img width="409" alt="image" src="https://github.com/user-attachments/assets/4f1fc7f8-916d-4888-ba59-b629ba354329">


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 새로운 기능: 로딩 컴포넌트가 추가되었습니다.
- 스타일링 변경: 로딩 컴포넌트의 높이가 `calc(100vh - 210px)`로 조정되었습니다.
- 리팩터링: 불필요한 주석 처리된 코드를 제거하였습니다.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->