### PR TITLE
Fix:  movemonth 부분 경로 변경

### DIFF
--- a/src/pages/salaryDetail/MoveMonth.tsx
+++ b/src/pages/salaryDetail/MoveMonth.tsx
@@ -17,14 +17,14 @@ export default function MoveMonth({ date, id, salaryData }: useMonthNavigationPr
   const handlePrevMonth = () => {
     if (!prevDisabled) {
       setCurrentMonth(currentMonth.subtract(1, 'month'));
-      navigate(`/salary-detail/${id - 1}`);
+      navigate(`/payments/${id - 1}`);
     }
   };
 
   const handleNextMonth = () => {
     if (!nextDisabled) {
       setCurrentMonth(currentMonth.add(1, 'month'));
-      navigate(`/salary-detail/${id + 1}`);
+      navigate(`/payments/${id + 1}`);
     }
   };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

movemonth 부분 경로 변경
salary-details -> payments

## 📋 작업 내용

movemonth 경로 변경... not found 저리가라

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: 변경된 URL 경로로 이전 월과 다음 월로 이동 시 사용자가 `/salary-detail/` 대신 `/payments/` 페이지로 올바르게 이동합니다.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->